### PR TITLE
Local time offset was lost when writing DateTimeOffset in non UTC format

### DIFF
--- a/src/Parquet.Test/EndToEndTypeTest.cs
+++ b/src/Parquet.Test/EndToEndTypeTest.cs
@@ -43,6 +43,7 @@ namespace Parquet.Test
             //Expected: 2017-07-13T10:58:44.3767154+00:00
             //Actual:   2017-07-12T10:58:44.3770000+00:00
             ["dateTimeOffset"] = (new DataField<DateTimeOffset>("dateTimeOffset"), new DateTimeOffset(DateTime.UtcNow.RoundToSecond())),
+            ["dateTimeOffsetWithOffset"] = (new DataField<DateTimeOffset>("dateTimeOffsetWithOffset"), new DateTimeOffset(new DateTime(2001, 12, 1, 0, 10, 0, DateTimeKind.Unspecified), TimeSpan.FromHours(3))),
             ["impala date"] = (new DateTimeDataField("dateImpala", DateTimeFormat.Impala), new DateTimeOffset(DateTime.UtcNow.RoundToSecond())),
             ["dateDateAndTime"] = (new DateTimeDataField("dateDateAndTime", DateTimeFormat.DateAndTime), new DateTimeOffset(DateTime.UtcNow.RoundToSecond())),
             // don't want any excess info in the offset INT32 doesn't contain or care about this data 
@@ -86,6 +87,7 @@ namespace Parquet.Test
       [InlineData("negative decimal")]
 
       [InlineData("dateTimeOffset")]
+      [InlineData("dateTimeOffsetWithOffset")]
       [InlineData("impala date")]
       [InlineData("dateDateAndTime")]
       [InlineData("dateDate")]

--- a/src/Parquet.Test/StatisticsTest.cs
+++ b/src/Parquet.Test/StatisticsTest.cs
@@ -23,67 +23,89 @@ namespace Parquet.Test
          public object Max { get; set; }
       }
 
+
       private static Dictionary<string, TestDesc> NameToTest = new Dictionary<string, TestDesc>
       {
-         ["int"] = new TestDesc
-         {
-            Type = typeof(int),
-            Data = new int[] { 4, 2, 1, 3, 5, 1, 4 },
-            NullCount = 0,
-            DistinctCount = 5,
-            Min = 1,
-            Max = 5
-         },
-         ["int?"] = new TestDesc
-         {
-            Type = typeof(int?),
-            Data = new int?[] { 4, 2, 1, 3, 1, null, 4 },
-            DistinctCount = 4,
-            NullCount = 1,
-            Min = 1,
-            Max = 4
-         },
-         ["string"] = new TestDesc
-         {
-            Type = typeof(string),
-            Data = new string[] { "one", "two", "one" },
-            NullCount = 0,
-            DistinctCount = 2,
-            Min = "one",
-            Max = "two"
-         },
-         ["float"] = new TestDesc
-         {
-            Type = typeof(float),
-            Data = new float[] { 1.23f, 2.1f, 0.5f, 0.5f },
-            DistinctCount = 3,
-            NullCount = 0,
-            Min = 0.5f,
-            Max = 2.1f
-         },
-         ["double"] = new TestDesc
-         {
-            Type = typeof(double),
-            Data = new double[] { 1.23D, 2.1D, 0.5D, 0.5D },
-            DistinctCount = 3,
-            NullCount = 0,
-            Min = 0.5D,
-            Max = 2.1D
-         },
-         ["dateTime"] = new TestDesc
+         ["int"] =
+            new TestDesc
+            {
+               Type = typeof(int),
+               Data = new int[] {4, 2, 1, 3, 5, 1, 4},
+               NullCount = 0,
+               DistinctCount = 5,
+               Min = 1,
+               Max = 5
+            },
+         ["int?"] =
+            new TestDesc
+            {
+               Type = typeof(int?),
+               Data = new int?[] {4, 2, 1, 3, 1, null, 4},
+               DistinctCount = 4,
+               NullCount = 1,
+               Min = 1,
+               Max = 4
+            },
+         ["string"] =
+            new TestDesc
+            {
+               Type = typeof(string),
+               Data = new string[] {"one", "two", "one"},
+               NullCount = 0,
+               DistinctCount = 2,
+               Min = "one",
+               Max = "two"
+            },
+         ["float"] =
+            new TestDesc
+            {
+               Type = typeof(float),
+               Data = new float[] {1.23f, 2.1f, 0.5f, 0.5f},
+               DistinctCount = 3,
+               NullCount = 0,
+               Min = 0.5f,
+               Max = 2.1f
+            },
+         ["double"] =
+            new TestDesc
+            {
+               Type = typeof(double),
+               Data = new double[] {1.23D, 2.1D, 0.5D, 0.5D},
+               DistinctCount = 3,
+               NullCount = 0,
+               Min = 0.5D,
+               Max = 2.1D
+            },
+         ["dateTime"] =
+            new TestDesc
+            {
+               Type = typeof(DateTime),
+               Data = new DateTimeOffset[]
+               {
+                  new DateTimeOffset(new DateTime(2019, 12, 16), TimeSpan.Zero),
+                  new DateTimeOffset(new DateTime(2019, 12, 16), TimeSpan.Zero),
+                  new DateTimeOffset(new DateTime(2019, 12, 15), TimeSpan.Zero),
+                  new DateTimeOffset(new DateTime(2019, 12, 17), TimeSpan.Zero)
+               },
+               DistinctCount = 3,
+               NullCount = 0,
+               Min = new DateTimeOffset(new DateTime(2019, 12, 15), TimeSpan.Zero),
+               Max = new DateTimeOffset(new DateTime(2019, 12, 17), TimeSpan.Zero)
+            },
+         ["dateTimeWithOffset"] = new TestDesc
          {
             Type = typeof(DateTime),
             Data = new DateTimeOffset[]
             {
-               new DateTimeOffset(new DateTime(2019, 12, 16)),
-               new DateTimeOffset(new DateTime(2019, 12, 16)),
-               new DateTimeOffset(new DateTime(2019, 12, 15)),
-               new DateTimeOffset(new DateTime(2019, 12, 17))
+               new DateTimeOffset(new DateTime(2019, 12, 16), TimeSpan.FromHours(5)),
+               new DateTimeOffset(new DateTime(2019, 12, 16), TimeSpan.FromHours(5)),
+               new DateTimeOffset(new DateTime(2019, 12, 15), TimeSpan.FromHours(5)),
+               new DateTimeOffset(new DateTime(2019, 12, 17), TimeSpan.FromHours(5))
             },
             DistinctCount = 3,
             NullCount = 0,
-            Min = new DateTimeOffset(new DateTime(2019, 12, 15)),
-            Max = new DateTimeOffset(new DateTime(2019, 12, 17))
+            Min = new DateTimeOffset(new DateTime(2019, 12, 15), TimeSpan.FromHours(5)),
+            Max = new DateTimeOffset(new DateTime(2019, 12, 17), TimeSpan.FromHours(5))
          }
       };
 
@@ -94,6 +116,7 @@ namespace Parquet.Test
       [InlineData("float")]
       [InlineData("double")]
       [InlineData("dateTime")]
+      [InlineData("dateTimeWithOffset")]
       public void Distinct_stat_for_basic_data_types(string name)
       {
          TestDesc test = NameToTest[name];

--- a/src/Parquet/File/Values/Primitives/NanoTime.cs
+++ b/src/Parquet/File/Values/Primitives/NanoTime.cs
@@ -16,6 +16,7 @@ namespace Parquet.File.Values.Primitives
 
       public NanoTime(DateTimeOffset dt)
       {
+         dt = dt.ToUniversalTime();
          int m = dt.Month;
          int d = dt.Day;
          int y = dt.Year;
@@ -27,7 +28,7 @@ namespace Parquet.File.Values.Primitives
          }
 
          _julianDay = d + (153 * m - 457) / 5 + 365 * y + (y / 4) - (y / 100) + (y / 400) + 1721119;
-         _timeOfDayNanos = (long)(dt.TimeOfDay.TotalMilliseconds * 1000000D);
+         _timeOfDayNanos = (long)(dt.TimeOfDay.TotalMilliseconds  * 1000000D);
       }
 
       public void Write(BinaryWriter writer)


### PR DESCRIPTION
For the writing part this would be a breaking change.

This PR converts the `DateTimeOffset` to universal time before converting it the INT96.

Currently parquet-dotnet appears to write everything as is, so any local offset would be lost when writing.  When reading it back in it would be read as if it was a UTC `DateTimeOffset` (which then of course gives a different time instant than what the user attempted to write).


