### PR TITLE
[ParquetColumn] was totally ignored on deserialization

### DIFF
--- a/src/Parquet.CLI/Help.Designer.cs
+++ b/src/Parquet.CLI/Help.Designer.cs
@@ -79,7 +79,7 @@ namespace Parquet.CLI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Converts between file formats. Currently supports conversion from parquet to multiline json only. When launched prints json documents to the terminal..
+        ///   Looks up a localized string similar to Converts between file formats. Supports conversion from parquet to multiline json or csv. When launched prints converted documents to the terminal..
         /// </summary>
         internal static string Command_Convert_Description {
             get {

--- a/src/Parquet.CLI/Help.resx
+++ b/src/Parquet.CLI/Help.resx
@@ -124,7 +124,7 @@
     <value>Path to parquet file.</value>
   </data>
   <data name="Command_Convert_Description" xml:space="preserve">
-    <value>Converts between file formats. Currently supports conversion from parquet to multiline json only. When launched prints json documents to the terminal.</value>
+    <value>Converts between file formats. Supports conversion from parquet to multiline json or csv. When launched prints converted documents to the terminal.</value>
   </data>
   <data name="Command_Convert_Format" xml:space="preserve">
     <value>Output format. By default uses 'json'. Supports 'json' or 'csv'.</value>

--- a/src/Parquet.Test/Parquet.Test.csproj
+++ b/src/Parquet.Test/Parquet.Test.csproj
@@ -27,10 +27,6 @@
    </ItemGroup>
 
    <ItemGroup>
-      <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-   </ItemGroup>
-
-   <ItemGroup>
       <None Update="data\**">
          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/src/Parquet/Data/Schema/Schema.cs
+++ b/src/Parquet/Data/Schema/Schema.cs
@@ -120,6 +120,11 @@ namespace Parquet.Data
          return result.ToArray();
       }
 
+      internal DataField FindDataField(string path)
+      {
+         return GetDataFields().FirstOrDefault(f => f.Path == path);
+      }
+
       /// <summary>
       /// Indicates whether the current object is equal to another object of the same type.
       /// </summary>

--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -2,7 +2,9 @@
 
    <PropertyGroup>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Description>Pure .NET library to read and write Apache Parquet files, targeting .NET 4.5 and .NET Standand 1.4 and up. Linux, Windows and Mac are first class citizens, but also works everywhere .NET is running (Android, iOS, IOT). Has zero dependencies on thrid-party libraries or any native code. Provides both low-level access to Apache Parquet files, and high-level utilities for more traditional and humanly understandable row-based access. Includes automatic serializer/deserializer from C# classes into parquet files that works by generating MSIL (bytecode) on the fly and is therefore super fast.</Description>
+    <Description>Pure managed .NET library to read and write Apache Parquet files, targeting .NET Standand 1.4 and up.
+
+Linux, Windows and Mac are first class citizens, but also works everywhere .NET is running (Android, iOS, IOT). Has zero dependencies on thrid-party libraries or any native code. Provides both low-level access to Apache Parquet files, and high-level utilities for more traditional and humanly understandable row-based access. Includes automatic serializer/deserializer from C# classes into parquet files that works by generating MSIL (bytecode) on the fly and is therefore super fast.</Description>
     <Company>Ivan Gavryliuk</Company>
     <PackageId>Parquet.Net</PackageId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Parquet/Serialization/SchemaReflector.cs
+++ b/src/Parquet/Serialization/SchemaReflector.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -13,6 +14,7 @@ namespace Parquet.Serialization
    public class SchemaReflector
    {
       private readonly TypeInfo _classType;
+      private static readonly ConcurrentDictionary<Type, Schema> _cachedReflectedSchemas = new ConcurrentDictionary<Type, Schema>();
 
       /// <summary>
       /// </summary>
@@ -44,7 +46,17 @@ namespace Parquet.Serialization
       /// <returns></returns>
       public static Schema Reflect<T>()
       {
-         return new SchemaReflector(typeof(T)).Reflect();
+         return _cachedReflectedSchemas.GetOrAdd(typeof(T), t => new SchemaReflector(typeof(T)).Reflect());
+      }
+
+      /// <summary>
+      /// 
+      /// </summary>
+      /// <param name="classType"></param>
+      /// <returns></returns>
+      public static Schema Reflect(Type classType)
+      {
+         return _cachedReflectedSchemas.GetOrAdd(classType, t => new SchemaReflector(classType).Reflect());
       }
 
       private Field GetField(PropertyInfo property)


### PR DESCRIPTION
### Fixes

Issue #29 

### Description

`[ParquetColumn]` was totally ignored on deserialisation, so it fails with renamed column

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).