### PR TITLE
Enhancement #28: Add ability to ignore properties

### DIFF
--- a/doc/serialisation.md
+++ b/doc/serialisation.md
@@ -61,6 +61,20 @@ class MyClass
 It supports the following properties:
 - **Name** overrides column name in the parquet file.
 
+### Ignoring properties while serializing
+
+You can ignore few properties from serialization process by decorating them with `ParquetIgnore` attribute.
+
+ with `[ParquetIgnore]` attribute:
+
+```csharp
+class MyClass
+{
+   [ParquetIgnore]
+   public int Id { get; set; }
+}
+```
+
 ## Limitations
 
 At the moment serialiser supports only simple first-level class *properties* (having a getter and a setter).

--- a/src/Parquet.Test/Serialisation/ParquetConvertTest.cs
+++ b/src/Parquet.Test/Serialisation/ParquetConvertTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NetBox.Extensions;
+using Parquet.Attributes;
 using Parquet.Data;
 using Parquet.Serialization;
 using Xunit;
@@ -11,6 +12,54 @@ namespace Parquet.Test.Serialisation
 {
    public class ParquetConvertTest : TestBase
    {
+      [Fact]
+      public void Serialise_Should_Exclude_IgnoredProperties_while_serialized_to_parquetfile()
+      {
+         DateTime now = DateTime.Now;
+
+         IEnumerable<StructureWithIgnoredProperties> structures = Enumerable
+            .Range(0, 10)
+            .Select(i => new StructureWithIgnoredProperties
+            {
+               Id = i,
+               Name = $"row {i}",
+               SSN = "000-00-0000",
+               NonNullableDecimal = 100.534M,
+               NullableDecimal = 99.99M,
+               NonNullableDateTime = DateTime.Now,
+               NullableDateTime = DateTime.Now,
+               NullableInt = 111,
+               NonNullableInt = 222
+            }) ;
+
+         using (var ms = new MemoryStream())
+         {
+            Schema schema = ParquetConvert.Serialize(structures, ms, compressionMethod: CompressionMethod.Snappy, rowGroupSize: 2);
+
+            ms.Position = 0;
+
+            StructureWithIgnoredProperties[] structures2 = ParquetConvert.Deserialize<StructureWithIgnoredProperties>(ms);
+
+            StructureWithIgnoredProperties[] structuresArray = structures.ToArray();
+            Func<Type, Object> GetDefaultValue = (type) => type.IsValueType ? Activator.CreateInstance(type) : null;
+
+            for (int i = 0; i < 10; i++)
+            {
+               Assert.Equal(structuresArray[i].Id, structures2[i].Id);
+               Assert.Equal(structuresArray[i].Name, structures2[i].Name);
+               //As serialization ignored these below properties, deserilizing these should always be null(or type's default value).
+               Assert.Equal(structures2[i].SSN, GetDefaultValue(typeof(string)));
+               Assert.Equal(structures2[i].NonNullableInt, GetDefaultValue(typeof(int)));
+               Assert.Equal(structures2[i].NullableInt, GetDefaultValue(typeof(int?)));
+               Assert.Equal(structures2[i].NonNullableDecimal, GetDefaultValue(typeof(decimal)));
+               Assert.Equal(structures2[i].NullableDecimal, GetDefaultValue(typeof(decimal?)));
+               Assert.Equal(structures2[i].NonNullableDateTime, GetDefaultValue(typeof(DateTime)));
+               Assert.Equal(structures2[i].NullableDateTime, GetDefaultValue(typeof(DateTime?)));
+            }
+
+         }
+      }
+
       [Fact]
       public void Serialise_deserialise_all_types()
       {
@@ -129,6 +178,30 @@ namespace Parquet.Test.Serialisation
          public string Name { get; set; }
 
          public DateTimeOffset Date { get; set; }
+      }
+      public class StructureWithIgnoredProperties
+      {
+         public int Id { get; set; }
+         public string Name { get; set; }
+
+         [ParquetIgnore]
+         public string SSN { get; set; }
+
+         [ParquetIgnore]
+         public DateTime NonNullableDateTime { get; set; }
+         [ParquetIgnore]
+         public DateTime? NullableDateTime { get; set; }
+
+         [ParquetIgnore]
+         public int NonNullableInt { get; set; }
+
+         [ParquetIgnore]
+         public int? NullableInt { get; set; }
+
+         [ParquetIgnore]
+         public decimal NonNullableDecimal { get; set; }
+         [ParquetIgnore]
+         public decimal? NullableDecimal { get; set; }
       }
 
       public class StructureWithTestType<T>

--- a/src/Parquet/Attributes/ParquetIgnoreAttribute.cs
+++ b/src/Parquet/Attributes/ParquetIgnoreAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Parquet.Attributes
+{
+   /// <summary>
+   /// Annotates a class property as a marker to ignore while serializing to parquet file
+   /// </summary>
+   [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+   public class ParquetIgnoreAttribute : Attribute
+   {
+   }
+}

--- a/src/Parquet/Serialization/SchemaReflector.cs
+++ b/src/Parquet/Serialization/SchemaReflector.cs
@@ -32,7 +32,7 @@ namespace Parquet.Serialization
       /// <returns></returns>
       public Schema Reflect()
       {
-         IEnumerable<PropertyInfo> properties = _classType.DeclaredProperties;
+         IEnumerable<PropertyInfo> properties = _classType.DeclaredProperties.Where(pickSerializableProperties);
 
          return new Schema(properties.Select(GetField).Where(p => p != null).ToList());
       }
@@ -68,5 +68,8 @@ namespace Parquet.Serialization
          r.ClrPropName = property.Name;
          return r;
       }
+
+      Func<PropertyInfo, bool> pickSerializableProperties = (PropertyInfo arg) => !arg.CustomAttributes.Any(p => p.AttributeType == typeof(ParquetIgnoreAttribute));
+
    }
 }


### PR DESCRIPTION
  - ParequetConvert serialize API should ignore properties marked with
  ignore attribute during serailization process to parquet file.


### Fixes

Issue #28 

### Description

desctiption goes here

[YES] I have included unit tests validating this fix.
[YES] I have updated markdown documentation where required.
[ YES] I understand that successful approval of my pull request requires reproducible tests as per  [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).