### PR TITLE
Fix issue with repetition levels when having nested lists in a table

### DIFF
--- a/src/Parquet.Test/Rows/RowsModelTest.cs
+++ b/src/Parquet.Test/Rows/RowsModelTest.cs
@@ -389,6 +389,32 @@ namespace Parquet.Test.Rows
 
       }
 
+      [Fact]
+      public void List_of_lists_read_write_structures()
+      {
+         var t = new Table(
+             new DataField<int>("id"),
+             new ListField(
+                 "items",
+                 new StructField(
+                     "item",
+                     new DataField<int>("id"),
+                     new ListField(
+                         "values",
+                         new DataField<string>("value")))));
+
+         t.Add(0, new[]
+         {
+            new Row(0, new[] { "0,0,0", "0,0,1", "0,0,2" }),
+            new Row(1, new[] { "0,1,0", "0,1,1", "0,1,2" }),
+            new Row(2, new[] { "0,2,0", "0,2,1", "0,2,2" }),
+         });
+
+         Table t1 = WriteRead(t);
+         Assert.Equal(3, ((object[])t1[0][1]).Length);
+         Assert.Equal(t.ToString(), t1.ToString(), ignoreLineEndingDifferences: true);
+      }
+
       #endregion
 
       #region [ Mixed ]

--- a/src/Parquet/Data/Rows/DataColumnAppender.cs
+++ b/src/Parquet/Data/Rows/DataColumnAppender.cs
@@ -20,8 +20,9 @@ namespace Parquet.Data.Rows
          _isRepeated = dataField.MaxRepetitionLevel > 0;
       }
 
-      public void Add(object value, int level, int index)
+      public void Add(object value, int level, LevelIndex[] indexes)
       {
+         int index = indexes[indexes.Length - 1].Index;
          if (_isRepeated)
          {
             if(!(value is string) && value is IEnumerable valueItems)

--- a/src/Parquet/Data/Rows/DataColumnAppender.cs
+++ b/src/Parquet/Data/Rows/DataColumnAppender.cs
@@ -19,7 +19,7 @@ namespace Parquet.Data.Rows
          _isRepeated = dataField.MaxRepetitionLevel > 0;
       }
 
-      public void Add(object value, int level, LevelIndex[] indexes)
+      public void Add(object value, LevelIndex[] indexes)
       {
          if (_isRepeated)
          {

--- a/src/Parquet/Data/Rows/LevelIndex.cs
+++ b/src/Parquet/Data/Rows/LevelIndex.cs
@@ -1,0 +1,34 @@
+﻿namespace Parquet.Data.Rows
+{
+   struct LevelIndex
+   {
+      public LevelIndex(int level, int index)
+      {
+         Level = level;
+         Index = index;
+      }
+
+      public int Level { get; set; }
+      public int Index { get; set; }
+
+      public override string ToString()
+      {
+         return $"Level: {Level}; Index: {Index}";
+      }
+
+      public override bool Equals(object obj)
+      {
+         if (obj is LevelIndex li &&
+            li.Index == Index &&
+            li.Level == Level)
+            return true;
+
+         return false;
+      }
+
+      public override int GetHashCode()
+      {
+         return Level.GetHashCode() * 17 + Index.GetHashCode();
+      }
+   }
+}

--- a/src/Parquet/Data/Rows/RowsToDataColumnsConverter.cs
+++ b/src/Parquet/Data/Rows/RowsToDataColumnsConverter.cs
@@ -45,7 +45,7 @@ namespace Parquet.Data.Rows
             switch (f.SchemaType)
             {
                case SchemaType.Data:
-                  ProcessDataValue(f, row[cellIndex], level, indexes);
+                  ProcessDataValue(f, row[cellIndex], indexes);
                   break;
 
                case SchemaType.Map:
@@ -87,7 +87,7 @@ namespace Parquet.Data.Rows
          {
             case SchemaType.Data:
                //list has a special case for simple elements where they are not wrapped in rows
-               ProcessDataValue(f, cellValue, level, indexes);
+               ProcessDataValue(f, cellValue, indexes);
                break;
             case SchemaType.Struct:
                ProcessRows(((StructField)f).Fields, (IReadOnlyCollection<Row>)cellValue, level, indexes);
@@ -97,7 +97,7 @@ namespace Parquet.Data.Rows
          }
       }
 
-      private void ProcessDataValue(Field f, object value, int level, LevelIndex[] indexes)
+      private void ProcessDataValue(Field f, object value, LevelIndex[] indexes)
       {
          //prepare value appender
          if(!_pathToDataColumn.TryGetValue(f.Path, out DataColumnAppender appender))
@@ -106,7 +106,7 @@ namespace Parquet.Data.Rows
             _pathToDataColumn[f.Path] = appender;
          }
 
-         appender.Add(value, level, indexes);
+         appender.Add(value, indexes);
       }
    }
 }

--- a/src/Parquet/Data/Rows/RowsToDataColumnsConverter.cs
+++ b/src/Parquet/Data/Rows/RowsToDataColumnsConverter.cs
@@ -19,7 +19,7 @@ namespace Parquet.Data.Rows
 
       public IReadOnlyCollection<DataColumn> Convert()
       {
-         ProcessRows(_schema.Fields, _rows, 0);
+         ProcessRows(_schema.Fields, _rows, 0, Array.Empty<LevelIndex>());
 
          List<DataColumn> result = _schema.GetDataFields()
             .Select(df => _pathToDataColumn[df.Path].ToDataColumn())
@@ -28,16 +28,16 @@ namespace Parquet.Data.Rows
          return result;
       }
 
-      private void ProcessRows(IReadOnlyCollection<Field> fields, IReadOnlyCollection<Row> rows, int level)
+      private void ProcessRows(IReadOnlyCollection<Field> fields, IReadOnlyCollection<Row> rows, int level, LevelIndex[] indexes)
       {
          int i = 0;
          foreach(Row row in rows)
          {
-            ProcessRow(fields, row, level, i++);
+            ProcessRow(fields, row, level, indexes.Append(new LevelIndex(level, i++)));
          }
       }
 
-      private void ProcessRow(IReadOnlyCollection<Field> fields, Row row, int level, int index)
+      private void ProcessRow(IReadOnlyCollection<Field> fields, Row row, int level, LevelIndex[] indexes)
       {
          int cellIndex = 0;
          foreach(Field f in fields)
@@ -45,19 +45,19 @@ namespace Parquet.Data.Rows
             switch (f.SchemaType)
             {
                case SchemaType.Data:
-                  ProcessDataValue(f, row[cellIndex], level, index);
+                  ProcessDataValue(f, row[cellIndex], level, indexes);
                   break;
 
                case SchemaType.Map:
-                  ProcessMap((MapField)f, (IReadOnlyCollection<Row>)row[cellIndex], level + 1);
+                  ProcessMap((MapField)f, (IReadOnlyCollection<Row>)row[cellIndex], level + 1, indexes);
                   break;
 
                case SchemaType.Struct:
-                  ProcessRow(((StructField)f).Fields, (Row)row[cellIndex], level + 1, index);
+                  ProcessRow(((StructField)f).Fields, (Row)row[cellIndex], level + 1, indexes);
                   break;
 
                case SchemaType.List:
-                  ProcessList((ListField)f, row[cellIndex], level + 1, index);
+                  ProcessList((ListField)f, row[cellIndex], level + 1, indexes);
                   break;
 
                default:
@@ -68,7 +68,7 @@ namespace Parquet.Data.Rows
          }
       }
 
-      private void ProcessMap(MapField mapField, IReadOnlyCollection<Row> mapRows, int level)
+      private void ProcessMap(MapField mapField, IReadOnlyCollection<Row> mapRows, int level, LevelIndex[] indexes)
       {
          var fields = new Field[] { mapField.Key, mapField.Value };
 
@@ -76,10 +76,10 @@ namespace Parquet.Data.Rows
          var valueCell = mapRows.Select(r => r[1]).ToList();
          var row = new Row(keyCell, valueCell);
 
-         ProcessRow(fields, row, level, 0);
+         ProcessRow(fields, row, level, indexes);
       }
 
-      private void ProcessList(ListField listField, object cellValue, int level, int index)
+      private void ProcessList(ListField listField, object cellValue, int level, LevelIndex[] indexes)
       {
          Field f = listField.Item;
 
@@ -87,17 +87,17 @@ namespace Parquet.Data.Rows
          {
             case SchemaType.Data:
                //list has a special case for simple elements where they are not wrapped in rows
-               ProcessDataValue(f, cellValue, level, index);
+               ProcessDataValue(f, cellValue, level, indexes);
                break;
             case SchemaType.Struct:
-               ProcessRows(((StructField)f).Fields, (IReadOnlyCollection<Row>)cellValue, level + 1);
+               ProcessRows(((StructField)f).Fields, (IReadOnlyCollection<Row>)cellValue, level, indexes);
                break;
             default:
                throw new NotSupportedException();
          }
       }
 
-      private void ProcessDataValue(Field f, object value, int level, int index)
+      private void ProcessDataValue(Field f, object value, int level, LevelIndex[] indexes)
       {
          //prepare value appender
          if(!_pathToDataColumn.TryGetValue(f.Path, out DataColumnAppender appender))
@@ -106,7 +106,7 @@ namespace Parquet.Data.Rows
             _pathToDataColumn[f.Path] = appender;
          }
 
-         appender.Add(value, level, index);
+         appender.Add(value, level, indexes);
       }
    }
 }

--- a/src/Parquet/Extensions/CollectionExtensions.cs
+++ b/src/Parquet/Extensions/CollectionExtensions.cs
@@ -116,5 +116,18 @@ namespace Parquet
 
          IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
       }
+
+      public static T[] Append<T>(this T[] array, T value)
+      {
+         int length = array?.Length ?? 0;
+         var newArray = new T[array.Length + 1];
+
+         if (length > 0)
+            array.CopyTo(newArray, 0);
+
+         newArray[newArray.Length - 1] = value;
+
+         return newArray;
+      }
    }
 }

--- a/src/Parquet/Extensions/CollectionExtensions.cs
+++ b/src/Parquet/Extensions/CollectionExtensions.cs
@@ -120,7 +120,7 @@ namespace Parquet
       public static T[] Append<T>(this T[] array, T value)
       {
          int length = array?.Length ?? 0;
-         var newArray = new T[array.Length + 1];
+         var newArray = new T[length + 1];
 
          if (length > 0)
             array.CopyTo(newArray, 0);


### PR DESCRIPTION
### Fixes

Issue #42 

### Description

This PR fixes an issue with incorrect repetition levels when writing a table that has nested list fields. 

The suggested implementation uses an array of [LocationIndex](https://github.com/rickykaare/parquet-dotnet/blob/458-nested-listfields/src/Parquet/Data/Rows/LevelIndex.cs)s to keep track of the indexes of the lists at all preceding levels, and uses this information to identify which level is changing its index (repetition level).

Changes include:
* [`881064f`](https://github.com/aloneguid/parquet-dotnet/commit/881064fb9223dfde7df595966804bbd340b1d799) Introduce LevelIndex to hold index information for each list in the path
* [`8a53ca6`](https://github.com/aloneguid/parquet-dotnet/commit/8a53ca637c093d811101c9e2a2a23a9f38e8cf4a) Introduce extension method for appending values to an array
* [`65c0967`](https://github.com/aloneguid/parquet-dotnet/commit/65c0967f3f6cd5cfc15030fe918f2e87a3a62622) Make level indexes available to the DataColumnAppender
* [`e18180f`](https://github.com/aloneguid/parquet-dotnet/commit/e18180f1cb45a75b8fa24c96110893c8cccbce16) Calculate correct repetition levels based on which level changed its index
* [`c67461f`](https://github.com/aloneguid/parquet-dotnet/commit/c67461f7da2bb727f8197830ac204ac0e4720309) Remove unused level parameter
* [`7a87fdb`](https://github.com/aloneguid/parquet-dotnet/commit/7a87fdb501c03dd2e9f7bd0a825c71db4bc0404e) Add unit test for validating fix

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->