### PR TITLE
16 integer serialization

### DIFF
--- a/src/Parquet.Test/Integration/ParquetMrIntegrationTest.cs
+++ b/src/Parquet.Test/Integration/ParquetMrIntegrationTest.cs
@@ -99,6 +99,22 @@ namespace Parquet.Test.Integration
       }
 
       [Fact]
+      public void Integers_all_types()
+      {
+         var table = new Table(new DataField<sbyte>("int8"), new DataField<byte>("uint8"),
+            new DataField<short>("int16"), new DataField<ushort>("uint16"),
+            new DataField<int>("int32"), new DataField<long>("int64"));
+
+         //generate fake data
+         for (int i = 0; i < 1000; i++)
+         {
+            table.Add(new Row((sbyte) (i % 127 - 255), (byte) (i % 255), (short) i, (ushort) i, i, (long) i));
+         }
+
+         CompareWithMr(table);
+      }
+
+      [Fact]
       public void Flat_simple_table()
       {
          var table = new Table(new DataField<int>("id"), new DataField<string>("city"));

--- a/src/Parquet/Data/Concrete/ByteDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/ByteDataTypeHandler.cs
@@ -16,12 +16,12 @@ namespace Parquet.Data.Concrete
 
       protected override byte ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadByte();
+         return (byte) reader.ReadInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, byte value)
       {
-         writer.Write(value);
+         writer.Write((int) value);
       }
    }
 }

--- a/src/Parquet/Data/Concrete/Int16DataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/Int16DataTypeHandler.cs
@@ -13,12 +13,12 @@ namespace Parquet.Data.Concrete
 
       protected override short ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadInt16();
+         return (short) reader.ReadInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, short value)
       {
-         writer.Write(value);
+         writer.Write((int) value);
       }
    }
 }

--- a/src/Parquet/Data/Concrete/SignedByteDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/SignedByteDataTypeHandler.cs
@@ -11,12 +11,12 @@ namespace Parquet.Data.Concrete
 
       protected override sbyte ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadSByte();
+         return (sbyte) reader.ReadInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, sbyte value)
       {
-         writer.Write(value);
+         writer.Write((int) value);
       }
    }
 }

--- a/src/Parquet/Data/Concrete/UnsignedInt16DataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/UnsignedInt16DataTypeHandler.cs
@@ -11,12 +11,12 @@ namespace Parquet.Data.Concrete
 
       protected override ushort ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadUInt16();
+         return (ushort) reader.ReadUInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, ushort value)
       {
-         writer.Write(value);
+         writer.Write((int) value);
       }
    }
 }


### PR DESCRIPTION
### Fixes

Issue #16 

### Description

Previously `(s)byte` and `(u)short` were serialized incorrectly. The Apache Parquet format requires them to be written as 32 bit integers. I've create a test using the **parquet-tools.jar** which failed previous to my fix and now succeeds. 

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->