### PR TITLE
Fix issue with reading and writing table with empty list field of structs

### DIFF
--- a/src/Parquet.Test/Reader/TestDataTest.cs
+++ b/src/Parquet.Test/Reader/TestDataTest.cs
@@ -79,6 +79,7 @@ namespace Parquet.Test.Reader
             typeof(DateTimeOffset?));
       }
 
+      [Fact]
       public void Alltypes_plain_no_compression_byte_arrays()
       {
          CompareFiles("types/alltypes", "plain", false,

--- a/src/Parquet.Test/Rows/RowsModelTest.cs
+++ b/src/Parquet.Test/Rows/RowsModelTest.cs
@@ -415,6 +415,24 @@ namespace Parquet.Test.Rows
          Assert.Equal(t.ToString(), t1.ToString(), ignoreLineEndingDifferences: true);
       }
 
+      [Fact]
+      public void List_of_structures_is_empty_read_write_structures()
+      {
+         Table t = new Table(
+            new DataField<int>("id"),
+            new ListField("structs",
+               new StructField("mystruct",
+                  new DataField<int>("id"),
+                  new DataField<string>("name"))));
+
+         t.Add(1, new Row[0]);
+         t.Add(2, new Row[0]);
+
+         Table t2 = WriteRead(t);
+
+         Assert.Equal(t.ToString(), t2.ToString(), ignoreLineEndingDifferences: true);
+      }
+
       #endregion
 
       #region [ Mixed ]

--- a/src/Parquet.Test/Rows/RowsModelTest.cs
+++ b/src/Parquet.Test/Rows/RowsModelTest.cs
@@ -433,6 +433,24 @@ namespace Parquet.Test.Rows
          Assert.Equal(t.ToString(), t2.ToString(), ignoreLineEndingDifferences: true);
       }
 
+      [Fact]
+      public void List_of_structures_is_empty_as_first_field_read_write_structures()
+      {
+         Table t = new Table(
+            new ListField("structs",
+               new StructField("mystruct",
+                  new DataField<int>("id"),
+                  new DataField<string>("name"))),
+            new DataField<int>("id"));
+
+         t.Add(new Row[0], 1);
+         t.Add(new Row[0], 2);
+
+         Table t2 = WriteRead(t);
+
+         Assert.Equal(t.ToString(), t2.ToString(), ignoreLineEndingDifferences: true);
+      }
+
       #endregion
 
       #region [ Mixed ]

--- a/src/Parquet/Data/Rows/DataColumnsToRowsConverter.cs
+++ b/src/Parquet/Data/Rows/DataColumnsToRowsConverter.cs
@@ -131,8 +131,8 @@ namespace Parquet.Data.Rows
 
          if(nestedPathTicks.Any(t => !t.moved))
          {
-            cell = null;
-            return false;
+            cell = new Row[0];
+            return true;
          }
 
          var nestedPathToColumn = nestedPathTicks

--- a/src/Parquet/Data/Rows/RowsToDataColumnsConverter.cs
+++ b/src/Parquet/Data/Rows/RowsToDataColumnsConverter.cs
@@ -22,7 +22,7 @@ namespace Parquet.Data.Rows
          ProcessRows(_schema.Fields, _rows, 0, Array.Empty<LevelIndex>());
 
          List<DataColumn> result = _schema.GetDataFields()
-            .Select(df => _pathToDataColumn[df.Path].ToDataColumn())
+            .Select(df => GetAppender(df).ToDataColumn())
             .ToList();
 
          return result;
@@ -99,6 +99,11 @@ namespace Parquet.Data.Rows
 
       private void ProcessDataValue(Field f, object value, LevelIndex[] indexes)
       {
+         GetAppender(f).Add(value, indexes);
+      }
+
+      private DataColumnAppender GetAppender(Field f)
+      {
          //prepare value appender
          if(!_pathToDataColumn.TryGetValue(f.Path, out DataColumnAppender appender))
          {
@@ -106,7 +111,7 @@ namespace Parquet.Data.Rows
             _pathToDataColumn[f.Path] = appender;
          }
 
-         appender.Add(value, indexes);
+         return appender;
       }
    }
 }

--- a/src/Parquet/ParquetRowGroupWriter.cs
+++ b/src/Parquet/ParquetRowGroupWriter.cs
@@ -62,7 +62,8 @@ namespace Parquet
 
          if (RowCount == null)
          {
-            RowCount = column.CalculateRowCount();
+            if (column.Data.Length > 0 || column.Field.MaxRepetitionLevel == 0)
+               RowCount = column.CalculateRowCount();
          }
 
          Thrift.SchemaElement tse = _thschema[_colIdx];
@@ -77,7 +78,7 @@ namespace Parquet
 
          var writer = new DataColumnWriter(_stream, _thriftStream, _footer, tse,
             _compressionMethod, _compressionLevel,
-            (int)RowCount.Value);
+            (int)(RowCount ?? 0));
 
          Thrift.ColumnChunk chunk = writer.Write(path, column, dataTypeHandler);
          _thriftRowGroup.Columns.Add(chunk);


### PR DESCRIPTION
### Fixes

Issue #49 

### Description

This PR fixes an issue with reading and writing a table with empty values for a list field of structures.

The suggested implementation extracts the logic of initializing the `DataColumnAppender`s to a method used to access the `_pathToDataColumn` dictionary. This way even the columns without data will be able to resolve an appender and produce a `DataColumn`.

Two other issues was found and fixed during testing:
* issue with reading Tables with an empty list field of structs
* issue with writing wrong RowCount when first field is empty ListField

Changes include:
* [`3bf79bc`](https://github.com/aloneguid/parquet-dotnet/commit/3bf79bcf58dcd80aa8bce9a7de055aa7bf51f1cc) Fix KeyNotFoundException: Use accessor method for dictionary
* [`2e383af`](https://github.com/aloneguid/parquet-dotnet/commit/2e383af183fd1c6314c9a857c4fa579326d7e258) Add unit test for writing empty list field of structs
* [`ca6db35`](https://github.com/aloneguid/parquet-dotnet/commit/ca6db356ef9be23e01448b8afe9b18f977607376) Fix issue with reading tables with empty list field of structs
* [`282f923`](https://github.com/aloneguid/parquet-dotnet/commit/282f923fcf20136036026ebe7ef2e14e47c009c2) Add missing FactAttribute to unit test
* [`c23541f`](https://github.com/aloneguid/parquet-dotnet/pull/50/commits/c23541f4644ef3dced953e57e83d3ef4defa8e23) Fix issue with RowCount when first field is empty ListField

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->