### PR TITLE
[WIP] run .net framework tests under windows

### DIFF
--- a/src/Parquet.Test/Parquet.Test.csproj
+++ b/src/Parquet.Test/Parquet.Test.csproj
@@ -6,6 +6,10 @@
       <LangVersion>latest</LangVersion>
    </PropertyGroup>
 
+   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+      <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+   </PropertyGroup>
+
    <PropertyGroup Condition="'$(Configuration)'=='Debug'">
       <DebugType>portable</DebugType>
       <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
### Fixes

Issue #51 

### Description

For sanity, Windows should run tests both under .net core and .net framework.