### PR TITLE
Deserialize only few properties 

### DIFF
--- a/doc/serialisation.md
+++ b/doc/serialisation.md
@@ -51,6 +51,33 @@ If you have a huge parquet file(~10million records), you can also retrieve recor
 ```csharp
 SimpleStructure[] structures = ParquetConvert.Deserialize<SimpleStructure>(stream,rowGroupIndex);
 ```
+### Deserialize only few properties:
+
+If you have a parquet file with huge number of columns and you only need few columns for processing, you can retrieve required columns only as described in the below code snippet.
+```csharp
+class MyClass
+{
+   public int Id { get; set; }
+   public string Name{get;set;}
+   public string Address{get;set;}
+   public int Age{get;set;}
+}
+class MyClassV1
+{
+   public string Name { get; set; }
+}
+SimpleStructure[] structures = Enumerable
+   .Range(0, 1000)
+   .Select(i => new SimpleStructure
+   {
+      Id = i,
+      Name = $"row {i}",
+   })
+   .ToArray();
+ParquetConvert.Serialize(structures, stream);
+
+MyClassV1[] v1structures = ParquetConvert.Deserialize<MyClassV1>(stream,rowGroupIndex);
+```
 
 ## Customising Serialisation
 

--- a/src/Parquet.Test/Serialisation/ParquetConvertTest.cs
+++ b/src/Parquet.Test/Serialisation/ParquetConvertTest.cs
@@ -122,6 +122,44 @@ namespace Parquet.Test.Serialisation
          }
       }
       [Fact]
+      public void Serialise_all_but_deserialise_only_few_properties()
+      {
+         DateTime now = DateTime.Now;
+
+         IEnumerable<SimpleStructure> structures = Enumerable
+            .Range(0, 10)
+            .Select(i => new SimpleStructure
+            {
+               Id = i,
+               NullableId = (i % 2 == 0) ? new int?() : new int?(i),
+               Name = $"row {i}",
+               Date = now.AddDays(i).RoundToSecond().ToUniversalTime()
+            });
+
+         using (var ms = new MemoryStream())
+         {
+            Schema schema = ParquetConvert.Serialize(structures, ms, compressionMethod: CompressionMethod.Snappy, rowGroupSize: 2);
+
+            ms.Position = 0;
+
+            SimpleStructure[] structuresArray = structures.ToArray();
+            int rowGroupCount = 5; //based on our test input. 10 records with rowgroup size 2.
+            for (int r = 0; r < rowGroupCount; r++)
+            {
+               SimpleStructureWithFewProperties[] rowGroupRecords = ParquetConvert.Deserialize<SimpleStructureWithFewProperties>(ms, rowGroupIndex: r);
+               Assert.Equal(2, rowGroupRecords.Length);
+
+               Assert.Equal(structuresArray[2 * r].Id, rowGroupRecords[0].Id);
+               Assert.Equal(structuresArray[2 * r].Name, rowGroupRecords[0].Name);
+               Assert.Equal(structuresArray[2 * r + 1].Id, rowGroupRecords[1].Id);
+               Assert.Equal(structuresArray[2 * r + 1].Name, rowGroupRecords[1].Name);
+
+            }
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => ParquetConvert.Deserialize<SimpleStructure>(ms, 5));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => ParquetConvert.Deserialize<SimpleStructure>(ms, 99999));
+         }
+      }
+      [Fact]
       public void Serialise_read_and_deserialise_by_rowgroup()
       {
          DateTime now = DateTime.Now;
@@ -289,6 +327,11 @@ namespace Parquet.Test.Serialisation
          public string Name { get; set; }
 
          public DateTimeOffset Date { get; set; }
+      }
+      public class SimpleStructureWithFewProperties
+      {
+         public int Id { get; set; }
+         public string Name { get; set; }
       }
       public class StructureWithIgnoredProperties
       {

--- a/src/Parquet/ParquetConvert.cs
+++ b/src/Parquet/ParquetConvert.cs
@@ -104,7 +104,7 @@ namespace Parquet
          var result = new List<T>();
          using (var reader = new ParquetReader(input))
          {
-            Schema fileSchema = reader.Schema;
+            Schema fileSchema = new SchemaReflector(typeof(T)).Reflect();
             DataField[] dataFields = fileSchema.GetDataFields();
 
             if (rowGroupIndex == -1) //Means read all row groups.


### PR DESCRIPTION
  - Serialize all properties and deserialize only few properties

### Fixes

Issue #
Current de-serialization doesn't support retrieving few properties.


- [Yes ] I have included unit tests validating this fix.
- [ Yes] I have updated markdown documentation where required.
- [Yes ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->