### PR TITLE
add TimeSpan DataField support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ var cityColumn = new DataColumn(
 // create file schema
 var schema = new Schema(idColumn.Field, cityColumn.Field);
 
-using (Stream fileStream = System.IO.File.OpenWrite("c:\\test.parquet"))
+using (Stream fileStream = System.IO.File.Create("c:\\test.parquet"))
 {
    using (var parquetWriter = new ParquetWriter(schema, fileStream))
    {

--- a/src/Parquet.Test/EndToEndTypeTest.cs
+++ b/src/Parquet.Test/EndToEndTypeTest.cs
@@ -49,7 +49,9 @@ namespace Parquet.Test
             // don't want any excess info in the offset INT32 doesn't contain or care about this data 
             ["dateDate"] = (new DateTimeDataField("dateDate", DateTimeFormat.Date), new DateTimeOffset(DateTime.UtcNow.RoundToDay(), TimeSpan.Zero)),
             ["interval"] = (new DataField<Interval>("interval"), new Interval(3, 2, 1)),
-
+            // time test(loses precision slightly)
+            ["time_micros"] = (new TimeSpanDataField("timeMicros", TimeSpanFormat.MicroSeconds), new TimeSpan(DateTime.UtcNow.TimeOfDay.Ticks / 10 * 10)),
+            ["time_millis"] = (new TimeSpanDataField("timeMillis", TimeSpanFormat.MilliSeconds), new TimeSpan(DateTime.UtcNow.TimeOfDay.Ticks / 10000 * 10000)),
 
             ["byte min value"] = (new DataField<byte>("byte"), byte.MinValue),
             ["byte max value"] = (new DataField<byte>("byte"), byte.MaxValue),
@@ -92,6 +94,8 @@ namespace Parquet.Test
       [InlineData("dateDateAndTime")]
       [InlineData("dateDate")]
       [InlineData("interval")]
+      [InlineData("time_micros")]
+      [InlineData("time_millis")]
 
       [InlineData("byte min value")]
       [InlineData("byte max value")]

--- a/src/Parquet/Attributes/ParquetColumnAttribute.cs
+++ b/src/Parquet/Attributes/ParquetColumnAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Parquet.Data;
 
 namespace Parquet.Attributes
 {
@@ -29,5 +30,15 @@ namespace Parquet.Attributes
       /// Column name. When undefined a default propety name is used which is simply the declared property name on the class.
       /// </summary>
       public string Name { get; set; }
+
+      /// <summary>
+      /// TmeSpanFormat. MilliSeconds or MicroSeconds
+      /// </summary>
+      public TimeSpanFormat TimeSpanFormat { get; set; }
+
+      /// <summary>
+      /// DateTimeFormat. Impala or DateAndTime or Date
+      /// </summary>
+      public DateTimeFormat DateTimeFormat { get; set; }
    }
 }

--- a/src/Parquet/Data/Concrete/TimeSpanDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/TimeSpanDataTypeHandler.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Parquet.Data;
+using Parquet.File.Values.Primitives;
+
+namespace Parquet.Data.Concrete
+{
+   class TimeSpanDataTypeHandler : BasicPrimitiveDataTypeHandler<TimeSpan>
+   {
+      public TimeSpanDataTypeHandler() : base(DataType.TimeSpan, Thrift.Type.INT64, Thrift.ConvertedType.TIME_MICROS)
+      {
+
+      }
+
+      public override bool IsMatch(Thrift.SchemaElement tse, ParquetOptions formatOptions)
+      {
+         return
+
+            (tse.Type == Thrift.Type.INT64 && tse.__isset.converted_type && tse.Converted_type == Thrift.ConvertedType.TIME_MICROS) ||
+
+            (tse.Type == Thrift.Type.INT32 && tse.__isset.converted_type && tse.Converted_type == Thrift.ConvertedType.TIME_MILLIS);
+      }
+
+      public override void CreateThrift(Field se, Thrift.SchemaElement parent, IList<Thrift.SchemaElement> container)
+      {
+         base.CreateThrift(se, parent, container);
+
+         //modify annotations
+         Thrift.SchemaElement tse = container.Last();
+         if (se is TimeSpanDataField dse)
+         {
+            switch (dse.TimeSpanFormat)
+            {
+               case TimeSpanFormat.MicroSeconds:
+                  tse.Type = Thrift.Type.INT64;
+                  tse.Converted_type = Thrift.ConvertedType.TIME_MICROS;
+                  break;
+               case TimeSpanFormat.MilliSeconds:
+                  tse.Type = Thrift.Type.INT32;
+                  tse.Converted_type = Thrift.ConvertedType.TIME_MILLIS;
+                  break;
+
+                  //other cases are just default
+            }
+         }
+         else
+         {
+            //default annotation is fine
+         }
+
+      }
+
+      public override int Read(BinaryReader reader, Thrift.SchemaElement tse, Array dest, int offset)
+      {
+         switch (tse.Type)
+         {
+            case Thrift.Type.INT32:
+               return ReadAsInt32(reader, (TimeSpan[])dest, offset);
+            case Thrift.Type.INT64:
+               return ReadAsInt64(reader, (TimeSpan[])dest, offset);
+            default:
+               throw new NotSupportedException();
+         }
+      }
+
+      protected override TimeSpan ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
+      {
+         if (tse == null) return default;
+
+         switch (tse.Type)
+         {
+            case Thrift.Type.INT32:
+               int iv = reader.ReadInt32();
+               return iv.FromUnixDays().TimeOfDay;
+            case Thrift.Type.INT64:
+               long lv = reader.ReadInt64();
+               return lv.FromUnixMilliseconds().TimeOfDay;
+            default:
+               throw new NotSupportedException();
+         }
+      }
+
+      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values, DataColumnStatistics statistics)
+      {
+         switch (tse.Type)
+         {
+            case Thrift.Type.INT32:
+               WriteAsInt32(writer, values);
+               break;
+            case Thrift.Type.INT64:
+               WriteAsInt64(writer, values);
+               break;
+            default:
+               throw new InvalidDataException($"data type '{tse.Type}' does not represent any date types");
+         }
+
+         if (statistics != null && values.Count > 0)
+         {
+            statistics.DistinctCount = ((IEnumerable<TimeSpan>)values).Distinct(this).Count();
+            statistics.MinValue = ((IEnumerable<TimeSpan>)values).Min();
+            statistics.MaxValue = ((IEnumerable<TimeSpan>)values).Max();
+         }
+      }
+
+      private static int ReadAsInt32(BinaryReader reader, TimeSpan[] dest, int offset)
+      {
+         int idx = offset;
+         while (reader.BaseStream.Position + 4 <= reader.BaseStream.Length)
+         {
+            dest[idx++] = ReadAsInt32(reader);
+         }
+
+         return idx - offset;
+      }
+
+      private static TimeSpan ReadAsInt32(BinaryReader reader)
+      {
+         int iv = reader.ReadInt32();
+         //TimeSpan e = iv.FromUnixDays();
+         TimeSpan e = new TimeSpan(0, 0, 0, 0, iv);
+         return e;
+      }
+
+      private static void WriteAsInt32(BinaryWriter writer, IList values)
+      {
+         foreach (TimeSpan dto in values)
+         {
+            WriteAsInt32(writer, dto);
+         }
+      }
+
+      private static void WriteAsInt32(BinaryWriter writer, TimeSpan dto)
+      {
+         int ms = (int)dto.TotalMilliseconds;
+         writer.Write(ms);
+      }
+
+      private static void ReadAsInt64(BinaryReader reader, IList result)
+      {
+         while (reader.BaseStream.Position + 8 <= reader.BaseStream.Length)
+         {
+            result.Add(ReadAsInt64(reader));
+         }
+      }
+
+      private static TimeSpan ReadAsInt64(BinaryReader reader)
+      {
+         long lv = reader.ReadInt64();
+         return new TimeSpan(lv*10);
+      }
+
+      private static int ReadAsInt64(BinaryReader reader, TimeSpan[] dest, int offset)
+      {
+         int idx = offset;
+
+         while (reader.BaseStream.Position + 8 <= reader.BaseStream.Length)
+         {
+            TimeSpan dto = ReadAsInt64(reader);
+            dest[idx++] = dto;
+         }
+
+         return idx - offset;
+      }
+
+      private static void WriteAsInt64(BinaryWriter writer, IList values)
+      {
+         foreach (TimeSpan dto in values)
+         {
+            WriteAsInt64(writer, dto);
+         }
+      }
+
+      private static void WriteAsInt64(BinaryWriter writer, TimeSpan dto)
+      {
+         long micros = dto.Ticks/10;
+         writer.Write(micros);
+      }
+
+      public override byte[] PlainEncode(Thrift.SchemaElement tse, TimeSpan x)
+      {
+         using (var ms = new MemoryStream())
+         {
+            using (var writer = new BinaryWriter(ms))
+            {
+               switch (tse.Type)
+               {
+                  case Thrift.Type.INT32:
+                     WriteAsInt32(writer, x);
+                     break;
+                  case Thrift.Type.INT64:
+                     WriteAsInt64(writer, x);
+                     break;
+                  default:
+                     throw new InvalidDataException($"data type '{tse.Type}' does not represent any date types");
+               }
+            }
+
+            return ms.ToArray();
+         }
+      }
+
+      public override object PlainDecode(Thrift.SchemaElement tse, byte[] encoded)
+      {
+         if (encoded == null) return null;
+
+         using (var ms = new MemoryStream(encoded))
+         {
+            using (var reader = new BinaryReader(ms))
+            {
+               switch (tse.Type)
+               {
+                  case Thrift.Type.INT32:
+                     return ReadAsInt32(reader);
+                  case Thrift.Type.INT64:
+                     return ReadAsInt64(reader);
+                  default:
+                     throw new NotSupportedException();
+               }
+            }
+         }
+      }
+   }
+}

--- a/src/Parquet/Data/DataType.cs
+++ b/src/Parquet/Data/DataType.cs
@@ -98,6 +98,11 @@
       /// <summary>
       /// Interval
       /// </summary>
-      Interval
+      Interval,
+
+      /// <summary>
+      /// TimeSpan
+      /// </summary>
+      TimeSpan,
    }
 }

--- a/src/Parquet/Data/DataTypeFactory.cs
+++ b/src/Parquet/Data/DataTypeFactory.cs
@@ -14,6 +14,7 @@ namespace Parquet.Data
          new DateTimeDataTypeHandler(),
          new IntervalDataTypeHandler(),
          new DecimalDataTypeHandler(),
+         new TimeSpanDataTypeHandler(),
 
          // low priority types
          new BooleanDataTypeHandler(),

--- a/src/Parquet/Data/Schema/TimeSpanDataField.cs
+++ b/src/Parquet/Data/Schema/TimeSpanDataField.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Parquet.Data
+{
+   /// <summary>
+   /// Schema element for <see cref="TimeSpan"/> which allows to specify precision
+   /// </summary>
+   public class TimeSpanDataField : DataField
+   {
+      /// <summary>
+      /// Desired data format, Parquet specific
+      /// </summary>
+      public TimeSpanFormat TimeSpanFormat { get; }
+
+      /// <summary>
+      /// Initializes a new instance of the <see cref="TimeSpanDataField"/> class.
+      /// </summary>
+      /// <param name="name">The name.</param>
+      /// <param name="format">The format.</param>
+      /// <param name="hasNulls">Is 'TimeSpan?'</param>
+      /// <param name="isArray"></param>
+      public TimeSpanDataField(string name, TimeSpanFormat format, bool hasNulls = true, bool isArray = false)
+         : base(name, DataType.TimeSpan, hasNulls, isArray)
+      {
+         TimeSpanFormat = format;
+      }
+   }
+}

--- a/src/Parquet/Data/TimeSpanFormat.cs
+++ b/src/Parquet/Data/TimeSpanFormat.cs
@@ -1,0 +1,24 @@
+﻿namespace Parquet.Data
+{
+   /// <summary>
+   /// Choice of representing time
+   /// </summary>
+   public enum TimeSpanFormat
+   {
+      /// <summary>
+      /// A time
+      /// 
+      /// The total number of milliseconds since midnight.  The value is stored
+      /// as an INT32 physical type.
+      /// </summary>
+      MilliSeconds,
+
+      /// <summary>
+      /// A time.
+      /// 
+      /// The total number of microseconds since midnight.  The value is stored as
+      /// an INT64 physical type.
+      /// </summary>
+      MicroSeconds
+   }
+}

--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -34,6 +34,10 @@ Linux, Windows and Mac are first class citizens, but also works everywhere .NET 
       <DefineConstants>NET14</DefineConstants>
    </PropertyGroup>
 
+   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.4|AnyCPU'">
+     <OutputPath>bin\</OutputPath>
+   </PropertyGroup>
+
    <ItemGroup>
     <PackageReference Include="IronSnappy" Version="1.1.0" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />

--- a/src/Parquet/Serialization/SchemaReflector.cs
+++ b/src/Parquet/Serialization/SchemaReflector.cs
@@ -78,8 +78,13 @@ namespace Parquet.Serialization
             property.PropertyType   //use CLR type here as DF constructor will figure out nullability and other parameters
          );
 
-         if (columnAttr != null && handler.ClrType == typeof(TimeSpan))
-            r = new TimeSpanDataField(r.Name, columnAttr.TimeSpanFormat, r.HasNulls, r.IsArray);
+         if (columnAttr != null)
+         {
+            if (handler.ClrType == typeof(TimeSpan))
+               r = new TimeSpanDataField(r.Name, columnAttr.TimeSpanFormat, r.HasNulls, r.IsArray);
+            if (handler.ClrType == typeof(DateTime) || handler.ClrType == typeof(DateTimeOffset))
+               r = new DateTimeDataField(r.Name, columnAttr.DateTimeFormat, r.HasNulls, r.IsArray);
+         }
 
          r.ClrPropName = property.Name;
 

--- a/src/Parquet/Serialization/SchemaReflector.cs
+++ b/src/Parquet/Serialization/SchemaReflector.cs
@@ -76,8 +76,13 @@ namespace Parquet.Serialization
 
          var r = new DataField(name,
             property.PropertyType   //use CLR type here as DF constructor will figure out nullability and other parameters
-            );
+         );
+
+         if (columnAttr != null && handler.ClrType == typeof(TimeSpan))
+            r = new TimeSpanDataField(r.Name, columnAttr.TimeSpanFormat, r.HasNulls, r.IsArray);
+
          r.ClrPropName = property.Name;
+
          return r;
       }
 


### PR DESCRIPTION
### Fixes

Issue #

### Description
add TimeSpan DataField support, MilliSeconds(INT32), MicroSeconds(INT64). ParquetColumnAttribute add TimeSpanFormat and DateTimeFormat, support custom SchemaReflector define.

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->