### PR TITLE
update nuget package, fix IronSnappy encode break issue

### DIFF
--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -35,9 +35,9 @@ Linux, Windows and Mac are first class citizens, but also works everywhere .NET 
    </PropertyGroup>
 
    <ItemGroup>
-    <PackageReference Include="IronSnappy" Version="1.1.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="IronSnappy" Version="1.2.2" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Fixes

update nuget package, fix IronSnappy encode break issue

### Description

update nuget package, fix IronSnappy encode break issue

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->