### PR TITLE
Make ClrType public from internal and update comment.

### DIFF
--- a/src/Parquet/Data/Schema/DataField.cs
+++ b/src/Parquet/Data/Schema/DataField.cs
@@ -25,9 +25,9 @@ namespace Parquet.Data
       public bool IsArray { get; }
 
       /// <summary>
-      /// CLR type of this column. Not sure whether to expose this externally yet.
+      /// CLR type of this column.
       /// </summary>
-      internal Type ClrType { get; private set; }
+      public Type ClrType { get; private set; }
 
       internal Type ClrNullableIfHasNullsType { get; private set; }
 

--- a/src/Parquet/Data/Schema/DataField.cs
+++ b/src/Parquet/Data/Schema/DataField.cs
@@ -29,7 +29,7 @@ namespace Parquet.Data
       /// </summary>
       public Type ClrType { get; private set; }
 
-      internal Type ClrNullableIfHasNullsType { get; private set; }
+      public Type ClrNullableIfHasNullsType { get; private set; }
 
       /// <summary>
       /// Creates a new instance of <see cref="DataField"/> by name and CLR type.


### PR DESCRIPTION
### Fixes

Issue #74 

### Description

Make `ClrType` and `ClrNullableIfHasNullsType` public from internal. 
As this is a trivial change, I added no test. I do not see any MD to update for this change.

- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->