### PR TITLE
Less String Allocation with a Configurable Ring Buffer.

### DIFF
--- a/src/Parquet.Test/ParquetWriterTest.cs
+++ b/src/Parquet.Test/ParquetWriterTest.cs
@@ -288,12 +288,18 @@ namespace Parquet.Test
             {
                Assert.Equal(repeats * 3, rg.RowCount);
                var parquetData = (string[])rg.ReadColumn(str).Data;
+
                Assert.Equal(string1, parquetData[0]);
                Assert.Equal(string1, parquetData[repeats - 1]);
+               Assert.True(ReferenceEquals(parquetData[0], parquetData[repeats - 1]));
+
                Assert.Equal(string2, parquetData[repeats]);
                Assert.Equal(string2, parquetData[repeats * 2 - 1]);
+               Assert.True(ReferenceEquals(parquetData[repeats], parquetData[repeats * 2 - 1]));
+
                Assert.Equal(string3, parquetData[repeats * 2]);
                Assert.Equal(string3, parquetData[repeats * 3 - 1]);               
+               Assert.True(ReferenceEquals(parquetData[repeats * 2], parquetData[repeats * 3 - 1]));
             }
          }
       }

--- a/src/Parquet/ParquetReader.cs
+++ b/src/Parquet/ParquetReader.cs
@@ -12,6 +12,28 @@ namespace Parquet
    /// </summary>
    public class ParquetReader : ParquetActor, IDisposable
    {
+      /// <summary>
+      /// In order to reduce the number of same-string
+      /// allocations, a running cache of recent strings
+      /// for a single column can be maintained and when
+      /// the same string is referenced again, the already
+      /// allocated string will be reused.
+      ///
+      /// This changes the look-back of how many strings to cache.
+      /// There is an inflection point where it will slow down parsing
+      /// as the match is a linear search through an array.
+      /// However, larger values will reduce memory if there
+      /// are many scattered common strings. A value of 1-5 is very
+      /// fast but will only catch the strings which repeat in a long series.
+      /// A value of 100 slows down but is a much more aggressive string reuse
+      /// and can reduce memory consumption.
+      ///
+      /// Default is 50 -- It gives good a good speed improvement. A value of 5
+      /// will eek out slightly better performance if you have long runs of repeated
+      /// strings.
+      /// </summary>
+      public static int StringCacheSize = 50;
+
       private readonly Stream _input;
       private readonly Thrift.FileMetaData _meta;
       private readonly ThriftFooter _footer;


### PR DESCRIPTION
I have a parquet file (which unfortunately I cannot share) with around 2.1M rows in it. The file covers a single month of data and contains a string field for the calendar quarter (e.g. 2020Q3). Thus the value is the same for all records. However, when it gets read, (I believe) the same string gets allocated 2.1M times -- eating up memory and slowing down parsing.

This implements a simple ring buffer with a configurable size. On my system with the particular file mentioned above, it reduces parsing time from ~14 seconds down to ~8 seconds.

Thank you.

--Bill
