### PR TITLE
Write performance improvements

### DIFF
--- a/src/Parquet/Data/ArrayView.cs
+++ b/src/Parquet/Data/ArrayView.cs
@@ -8,30 +8,37 @@ namespace Parquet.Data
    /// </summary>
    class ArrayView
    {
-      readonly Array _array;
+      private readonly Array _array;
 
-      public ArrayView(Array array, int count)
+      public ArrayView(Array array)
       {
-         Count = count;
+         Count = array.Length;
          _array = array;
       }
 
-      public ArrayView(Array array) : this(array, array.Length)
+      public static WritableArrayView<T> CreateWritable<T>(int length)
+      {
+         return new WritableArrayView<T>(length);
+      }
+
+      public virtual int Count { get; }
+
+      protected virtual void ReturnArray()
       {
       }
 
-      public int Count { get; }
-
-      public IEnumerable<T> GetValues<T>()
+      public IEnumerable<T> GetValuesAndReturnArray<T>()
       {
          T[] typed = (T[]) _array;
          for (int i = 0; i < Count; i++)
          {
             yield return typed[i];
          }
+
+         ReturnArray();
       }
 
-      public IEnumerable<T> GetValues<T>(DataColumnStatistics statistics, IEqualityComparer<T> equalityComparer, IComparer<T> comparer)
+      public IEnumerable<T> GetValuesAndReturnArray<T>(DataColumnStatistics statistics, IEqualityComparer<T> equalityComparer, IComparer<T> comparer)
       {
          T[] typed = (T[]) _array;
          if (statistics == null)
@@ -40,6 +47,8 @@ namespace Parquet.Data
             {
                yield return typed[i];
             }
+
+            ReturnArray();
 
             yield break;
          }
@@ -56,7 +65,7 @@ namespace Parquet.Data
          {
             T current = typed[i];
             yield return current;
-            
+
             hashSet.Add(current);
 
             if (i == 0)
@@ -84,6 +93,8 @@ namespace Parquet.Data
          statistics.MinValue = min;
          statistics.MaxValue = max;
          statistics.DistinctCount = hashSet.Count;
+
+         ReturnArray();
       }
    }
 }

--- a/src/Parquet/Data/ArrayView.cs
+++ b/src/Parquet/Data/ArrayView.cs
@@ -9,6 +9,7 @@ namespace Parquet.Data
    class ArrayView
    {
       private readonly Array _array;
+      private bool _consumed;
 
       public ArrayView(Array array)
       {
@@ -29,6 +30,7 @@ namespace Parquet.Data
 
       public IEnumerable<T> GetValuesAndReturnArray<T>()
       {
+         AssertNotConsumed();
          T[] typed = (T[]) _array;
          for (int i = 0; i < Count; i++)
          {
@@ -36,10 +38,12 @@ namespace Parquet.Data
          }
 
          ReturnArray();
+         _consumed = true;
       }
 
       public IEnumerable<T> GetValuesAndReturnArray<T>(DataColumnStatistics statistics, IEqualityComparer<T> equalityComparer, IComparer<T> comparer)
       {
+         AssertNotConsumed();
          T[] typed = (T[]) _array;
          if (statistics == null)
          {
@@ -95,6 +99,15 @@ namespace Parquet.Data
          statistics.DistinctCount = hashSet.Count;
 
          ReturnArray();
+         _consumed = true;
+      }
+
+      void AssertNotConsumed()
+      {
+         if (_consumed)
+         {
+            throw new InvalidOperationException("Cannot call GetValuesAndReturnArray twice");
+         }
       }
    }
 }

--- a/src/Parquet/Data/ArrayView.cs
+++ b/src/Parquet/Data/ArrayView.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Parquet.Data
+{
+   /// <summary>
+   /// Encapsulate an array and the length of the array used 
+   /// </summary>
+   class ArrayView
+   {
+      readonly Array _array;
+
+      public ArrayView(Array array, int count)
+      {
+         Count = count;
+         _array = array;
+      }
+
+      public ArrayView(Array array) : this(array, array.Length)
+      {
+      }
+
+      public int Count { get; }
+
+      public IEnumerable<T> GetValues<T>()
+      {
+         T[] typed = (T[]) _array;
+         for (int i = 0; i < Count; i++)
+         {
+            yield return typed[i];
+         }
+      }
+
+      public IEnumerable<T> GetValues<T>(DataColumnStatistics statistics, IEqualityComparer<T> equalityComparer, IComparer<T> comparer)
+      {
+         T[] typed = (T[]) _array;
+         if (statistics == null)
+         {
+            for (int i = 0; i < Count; i++)
+            {
+               yield return typed[i];
+            }
+
+            yield break;
+         }
+         // there's a big win here if you can use the ctor from NET Standard 2.1 that has a capacity, which avoids GC overhead of resize
+#if NETSTANDARD2_1
+         HashSet<T> hashSet = new HashSet<T>(Count, equalityComparer);
+#else
+         HashSet<T> hashSet = new HashSet<T>(equalityComparer);
+#endif
+
+         T min = default;
+         T max = default;
+         for (int i = 0; i < Count; i++)
+         {
+            T current = typed[i];
+            yield return current;
+            
+            hashSet.Add(current);
+
+            if (i == 0)
+            {
+               min = current;
+               max = current;
+            }
+            else
+            {
+               int cmin = comparer.Compare(min, current);
+               int cmax = comparer.Compare(max, current);
+
+               if (cmin > 0)
+               {
+                  min = current;
+               }
+
+               if (cmax < 0)
+               {
+                  max = current;
+               }
+            }
+         }
+
+         statistics.MinValue = min;
+         statistics.MaxValue = max;
+         statistics.DistinctCount = hashSet.Count;
+      }
+   }
+}

--- a/src/Parquet/Data/BasicDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicDataTypeHandler.cs
@@ -78,7 +78,7 @@ namespace Parquet.Data
 
       public virtual void Write(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values, DataColumnStatistics statistics)
       {
-         foreach (TSystemType one in values.GetValues(statistics, this, this))
+         foreach (TSystemType one in values.GetValuesAndReturnArray(statistics, this, this))
          {
             WriteOne(writer, one);
          }
@@ -129,7 +129,7 @@ namespace Parquet.Data
          definitionsLength = data.Length;
 
          nullCount = 0;
-         TNullable[] result = new TNullable[data.Length];
+         WritableArrayView<TNullable> result = ArrayView.CreateWritable<TNullable>(data.Length);
          int ir = 0;
 
          for (int i = 0; i < data.Length; i++)
@@ -147,8 +147,8 @@ namespace Parquet.Data
                result[ir++] = value;
             }
          }
-         
-         return new ArrayView(result, data.Length - nullCount);
+
+         return result;
       }
 
       protected T[] UnpackGenericDefinitions<T>(T[] src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)

--- a/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
@@ -77,7 +77,7 @@ namespace Parquet.Data
          definitionLevels = IntPool.Rent(data.Length);
          definitionsLength = data.Length;
 
-         TSystemType[] result = new TSystemType[data.Length];
+         WritableArrayView<TSystemType> result = ArrayView.CreateWritable<TSystemType>(data.Length);
          int ir = 0;
          nullCount = 0;
          
@@ -96,8 +96,8 @@ namespace Parquet.Data
                result[ir++] = value.Value;
             }
          }
-         
-         return new ArrayView(result, data.Length - nullCount);
+
+         return result;
       }
 
       public override int Compare(TSystemType x, TSystemType y)

--- a/src/Parquet/Data/Concrete/BooleanDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/BooleanDataTypeHandler.cs
@@ -50,7 +50,7 @@ namespace Parquet.Data.Concrete
          byte[] buffer = new byte[values.Count / 8 + 1];
          int ib = 0;
 
-         foreach (bool flag in values.GetValues<bool>())
+         foreach (bool flag in values.GetValuesAndReturnArray<bool>())
          {
             if (flag)
             {

--- a/src/Parquet/Data/Concrete/BooleanDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/BooleanDataTypeHandler.cs
@@ -43,14 +43,14 @@ namespace Parquet.Data.Concrete
          return reader.ReadBoolean();
       }
 
-      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values, DataColumnStatistics statistics)
+      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values, DataColumnStatistics statistics)
       {
          int n = 0;
          byte b = 0;
          byte[] buffer = new byte[values.Count / 8 + 1];
          int ib = 0;
 
-         foreach (bool flag in values)
+         foreach (bool flag in values.GetValues<bool>())
          {
             if (flag)
             {

--- a/src/Parquet/Data/Concrete/ByteArrayDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/ByteArrayDataTypeHandler.cs
@@ -73,9 +73,9 @@ namespace Parquet.Data.Concrete
          return reader.ReadBytes(length);
       }
 
-      public override Array PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
+      public override ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
       {
-         return PackDefinitions<byte[]>((byte[][])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
+         return PackDefinitions((byte[][])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }
 
       public override Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)

--- a/src/Parquet/Data/Concrete/DateTimeOffsetDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/DateTimeOffsetDataTypeHandler.cs
@@ -129,7 +129,7 @@ namespace Parquet.Data.Concrete
 
       private void WriteAsInt32(BinaryWriter writer, ArrayView values, DataColumnStatistics dataColumnStatistics)
       {
-         foreach (DateTimeOffset dto in values.GetValues(dataColumnStatistics, this, this))
+         foreach (DateTimeOffset dto in values.GetValuesAndReturnArray(dataColumnStatistics, this, this))
          {
             WriteAsInt32(writer, dto);
          }
@@ -170,7 +170,7 @@ namespace Parquet.Data.Concrete
 
       private void WriteAsInt64(BinaryWriter writer, ArrayView values, DataColumnStatistics dataColumnStatistics)
       {
-         foreach (DateTimeOffset dto in values.GetValues(dataColumnStatistics, this, this))
+         foreach (DateTimeOffset dto in values.GetValuesAndReturnArray(dataColumnStatistics, this, this))
          {
             WriteAsInt64(writer, dto);
          }
@@ -209,7 +209,7 @@ namespace Parquet.Data.Concrete
 
       private void WriteAsInt96(BinaryWriter writer, ArrayView values, DataColumnStatistics dataColumnStatistics)
       {
-         foreach (DateTimeOffset dto in values.GetValues<DateTimeOffset>(dataColumnStatistics, this, this))
+         foreach (DateTimeOffset dto in values.GetValuesAndReturnArray<DateTimeOffset>(dataColumnStatistics, this, this))
          {
             WriteAsInt96(writer, dto);
          }

--- a/src/Parquet/Data/Concrete/DecimalDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/DecimalDataTypeHandler.cs
@@ -150,7 +150,7 @@ namespace Parquet.Data.Concrete
       private void WriteAsInt32(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values)
       {
          double scaleFactor = Math.Pow(10, tse.Scale);
-         foreach (decimal d in values.GetValues<decimal>())
+         foreach (decimal d in values.GetValuesAndReturnArray<decimal>())
          {
             try
             {
@@ -194,7 +194,7 @@ namespace Parquet.Data.Concrete
       {
          double scaleFactor = Math.Pow(10, tse.Scale);
 
-         foreach (decimal d in values.GetValues<decimal>())
+         foreach (decimal d in values.GetValuesAndReturnArray<decimal>())
          {
             try
             {
@@ -244,7 +244,7 @@ namespace Parquet.Data.Concrete
 
       private void WriteAsFixedLengthByteArray(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values)
       {
-         foreach (decimal d in values.GetValues<decimal>())
+         foreach (decimal d in values.GetValuesAndReturnArray<decimal>())
          {
             var bd = new BigDecimal(d, tse.Precision, tse.Scale);
             byte[] itemData = bd.ToByteArray();

--- a/src/Parquet/Data/Concrete/DecimalDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/DecimalDataTypeHandler.cs
@@ -104,7 +104,7 @@ namespace Parquet.Data.Concrete
          }
       }
 
-      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values, DataColumnStatistics statistics)
+      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values, DataColumnStatistics statistics)
       {
          switch(tse.Type)
          {
@@ -147,10 +147,10 @@ namespace Parquet.Data.Concrete
       }
 
 
-      private void WriteAsInt32(Thrift.SchemaElement tse, BinaryWriter writer, IList values)
+      private void WriteAsInt32(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values)
       {
          double scaleFactor = Math.Pow(10, tse.Scale);
-         foreach (decimal d in values)
+         foreach (decimal d in values.GetValues<decimal>())
          {
             try
             {
@@ -190,11 +190,11 @@ namespace Parquet.Data.Concrete
       }
 
 
-      private void WriteAsInt64(Thrift.SchemaElement tse, BinaryWriter writer, IList values)
+      private void WriteAsInt64(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values)
       {
          double scaleFactor = Math.Pow(10, tse.Scale);
 
-         foreach (decimal d in values)
+         foreach (decimal d in values.GetValues<decimal>())
          {
             try
             {
@@ -242,9 +242,9 @@ namespace Parquet.Data.Concrete
          return offset - start;
       }
 
-      private void WriteAsFixedLengthByteArray(Thrift.SchemaElement tse, BinaryWriter writer, IList values)
+      private void WriteAsFixedLengthByteArray(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values)
       {
-         foreach (decimal d in values)
+         foreach (decimal d in values.GetValues<decimal>())
          {
             var bd = new BigDecimal(d, tse.Precision, tse.Scale);
             byte[] itemData = bd.ToByteArray();

--- a/src/Parquet/Data/Concrete/IntervalDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/IntervalDataTypeHandler.cs
@@ -54,9 +54,9 @@ namespace Parquet.Data.Concrete
          return new Interval(months, days, millis);
       }
 
-      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values, DataColumnStatistics statistics)
+      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values, DataColumnStatistics statistics)
       {
-         foreach(Interval interval in values)
+         foreach(Interval interval in values.GetValues<Interval>())
          {
             writer.Write(interval.Months);
             writer.Write(interval.Days);

--- a/src/Parquet/Data/Concrete/IntervalDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/IntervalDataTypeHandler.cs
@@ -56,7 +56,7 @@ namespace Parquet.Data.Concrete
 
       public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values, DataColumnStatistics statistics)
       {
-         foreach(Interval interval in values.GetValues<Interval>())
+         foreach(Interval interval in values.GetValuesAndReturnArray<Interval>())
          {
             writer.Write(interval.Months);
             writer.Write(interval.Days);

--- a/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
@@ -2,7 +2,6 @@
 using System.Buffers;
 using System.IO;
 using System.Text;
-using Parquet.Extensions;
 
 namespace Parquet.Data.Concrete
 {
@@ -11,7 +10,7 @@ namespace Parquet.Data.Concrete
       private static readonly Encoding E = Encoding.UTF8;
       private static readonly ArrayPool<byte> _bytePool = ArrayPool<byte>.Shared;
       private static readonly ArrayPool<string> _stringPool = ArrayPool<string>.Shared;
-
+      
       public StringDataTypeHandler() : base(DataType.String, Thrift.Type.BYTE_ARRAY, Thrift.ConvertedType.UTF8)
       {
       }
@@ -97,7 +96,7 @@ namespace Parquet.Data.Concrete
 
       public override ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
       {
-         return PackDefinitions<string>((string[])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
+         return PackDefinitions((string[])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }
 
       public override Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)
@@ -133,12 +132,12 @@ namespace Parquet.Data.Concrete
 
       public override int Compare(string x, string y)
       {
-         return string.Compare(x, y);
+         return string.CompareOrdinal(x, y);
       }
 
       public override bool Equals(string x, string y)
       {
-         return string.Equals(x, y);
+         return string.CompareOrdinal(x, y) == 0;
       }
 
       public override byte[] PlainEncode(Thrift.SchemaElement tse, string x)

--- a/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
@@ -95,7 +95,7 @@ namespace Parquet.Data.Concrete
          return ReadSingle(reader, tse, length, true);
       }
 
-      public override Array PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
+      public override ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
       {
          return PackDefinitions<string>((string[])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }

--- a/src/Parquet/Data/Concrete/TimeSpanDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/TimeSpanDataTypeHandler.cs
@@ -120,7 +120,7 @@ namespace Parquet.Data.Concrete
 
       private void WriteAsInt32(BinaryWriter writer, ArrayView values, DataColumnStatistics dataColumnStatistics)
       {
-         foreach (TimeSpan dto in values.GetValues(dataColumnStatistics, this, this))
+         foreach (TimeSpan dto in values.GetValuesAndReturnArray(dataColumnStatistics, this, this))
          {
             WriteAsInt32(writer, dto);
          }
@@ -161,7 +161,7 @@ namespace Parquet.Data.Concrete
 
       private void WriteAsInt64(BinaryWriter writer, ArrayView values, DataColumnStatistics dataColumnStatistics)
       {
-         foreach (TimeSpan dto in values.GetValues(dataColumnStatistics, this, this))
+         foreach (TimeSpan dto in values.GetValuesAndReturnArray(dataColumnStatistics, this, this))
          {
             WriteAsInt64(writer, dto);
          }

--- a/src/Parquet/Data/Concrete/TimeSpanDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/TimeSpanDataTypeHandler.cs
@@ -84,25 +84,18 @@ namespace Parquet.Data.Concrete
          }
       }
 
-      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values, DataColumnStatistics statistics)
+      public override void Write(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values, DataColumnStatistics statistics)
       {
          switch (tse.Type)
          {
             case Thrift.Type.INT32:
-               WriteAsInt32(writer, values);
+               WriteAsInt32(writer, values, statistics);
                break;
             case Thrift.Type.INT64:
-               WriteAsInt64(writer, values);
+               WriteAsInt64(writer, values, statistics);
                break;
             default:
                throw new InvalidDataException($"data type '{tse.Type}' does not represent any date types");
-         }
-
-         if (statistics != null && values.Count > 0)
-         {
-            statistics.DistinctCount = ((IEnumerable<TimeSpan>)values).Distinct(this).Count();
-            statistics.MinValue = ((IEnumerable<TimeSpan>)values).Min();
-            statistics.MaxValue = ((IEnumerable<TimeSpan>)values).Max();
          }
       }
 
@@ -125,9 +118,9 @@ namespace Parquet.Data.Concrete
          return e;
       }
 
-      private static void WriteAsInt32(BinaryWriter writer, IList values)
+      private void WriteAsInt32(BinaryWriter writer, ArrayView values, DataColumnStatistics dataColumnStatistics)
       {
-         foreach (TimeSpan dto in values)
+         foreach (TimeSpan dto in values.GetValues(dataColumnStatistics, this, this))
          {
             WriteAsInt32(writer, dto);
          }
@@ -166,9 +159,9 @@ namespace Parquet.Data.Concrete
          return idx - offset;
       }
 
-      private static void WriteAsInt64(BinaryWriter writer, IList values)
+      private void WriteAsInt64(BinaryWriter writer, ArrayView values, DataColumnStatistics dataColumnStatistics)
       {
-         foreach (TimeSpan dto in values)
+         foreach (TimeSpan dto in values.GetValues(dataColumnStatistics, this, this))
          {
             WriteAsInt64(writer, dto);
          }

--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -81,7 +81,7 @@ namespace Parquet.Data
       /// </summary>
       public DataColumnStatistics Statistics { get; internal set; } = new DataColumnStatistics(0, 0, null, null);
 
-      internal Array PackDefinitions(int maxDefinitionLevel, out int[] pooledDefinitionLevels, out int definitionLevelCount, out int nullCount)
+      internal ArrayView PackDefinitions(int maxDefinitionLevel, out int[] pooledDefinitionLevels, out int definitionLevelCount, out int nullCount)
       {
          pooledDefinitionLevels = ArrayPool<int>.Shared.Rent(Data.Length);
          definitionLevelCount = Data.Length;
@@ -92,7 +92,7 @@ namespace Parquet.Data
          {
             SetPooledDefinitionLevels(maxDefinitionLevel, pooledDefinitionLevels);
             nullCount = 0; //definitely no nulls here
-            return Data;
+            return new ArrayView(Data);
          }
 
          return _dataTypeHandler.PackDefinitions(Data, maxDefinitionLevel, out pooledDefinitionLevels, out definitionLevelCount, out nullCount);

--- a/src/Parquet/Data/IDataTypeHandler.cs
+++ b/src/Parquet/Data/IDataTypeHandler.cs
@@ -35,7 +35,7 @@ namespace Parquet.Data
       /// <param name="length">Number of bytes to read (type specific). Pass -1 to read the length from incoming stream if you don't know how long the buffer is.</param>
       object Read(BinaryReader reader, Thrift.SchemaElement tse, int length);
 
-      void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values, DataColumnStatistics statistics);
+      void Write(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values, DataColumnStatistics statistics);
 
       /// <summary>
       /// Creates or rents a native array
@@ -48,7 +48,7 @@ namespace Parquet.Data
 
       Array MergeDictionary(Array dictionary, int[] indexes, Array data, int offset, int length);
 
-      Array PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount);
+      ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount);
 
       Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags);
 

--- a/src/Parquet/Data/NonDataDataTypeHandler.cs
+++ b/src/Parquet/Data/NonDataDataTypeHandler.cs
@@ -32,7 +32,7 @@ namespace Parquet.Data
       public object Read(BinaryReader reader, Thrift.SchemaElement tse, int length) => throw new NotSupportedException();
 
 
-      public void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values, DataColumnStatistics statistics)
+      public void Write(Thrift.SchemaElement tse, BinaryWriter writer, ArrayView values, DataColumnStatistics statistics)
       {
          throw new NotSupportedException();
       }
@@ -42,7 +42,7 @@ namespace Parquet.Data
          throw new NotSupportedException();
       }
 
-      public Array PackDefinitions(Array data,  int maxDefiniionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
+      public ArrayView PackDefinitions(Array data,  int maxDefiniionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
       {
          throw new NotImplementedException();
       }

--- a/src/Parquet/Data/WritableArrayView.cs
+++ b/src/Parquet/Data/WritableArrayView.cs
@@ -1,0 +1,39 @@
+﻿using System.Buffers;
+
+namespace Parquet.Data
+{
+   class WritableArrayView<T> : ArrayView
+   {
+      private static readonly ArrayPool<T> ArrayPool = ArrayPool<T>.Shared;
+      private readonly T[] _typedArray;
+      int _count;
+
+      public WritableArrayView(int length) : this(ArrayPool.Rent(length))
+      {
+      }
+
+      WritableArrayView(T[] array) : base(array)
+      {
+         _typedArray = array;
+      }
+
+      public override int Count => _count;
+
+      protected override void ReturnArray()
+      {
+         ArrayPool.Return(_typedArray);
+      }
+
+      public T this[int i]
+      {
+         set
+         {
+            {
+               _typedArray[i] = value;
+               int count = i + 1;
+               if (count > _count) _count = count;
+            }
+         }
+      }
+   }
+}

--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -95,7 +94,7 @@ namespace Parquet.File
                      WriteLevels(writer, column.RepetitionLevels, column.RepetitionLevels.Length, maxRepetitionLevel);
                   }
 
-                  Array data = column.Data;
+                  ArrayView data = new ArrayView(column.Data);
 
                   if (maxDefinitionLevel > 0)
                   {

--- a/src/Parquet/File/StringListComparer.cs
+++ b/src/Parquet/File/StringListComparer.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+
+namespace Parquet.File
+{
+   /// <summary>
+   /// Wraps a list of strings and provides equality 
+   /// </summary>
+   class StringListComparer
+   {
+      private readonly List<string> _key;
+
+      public StringListComparer(List<string> key)
+      {
+         _key = key;
+      }
+      
+      public override bool Equals(object obj)
+      {
+         return obj is StringListComparer s && Equals(s);
+      }
+
+      bool Equals(StringListComparer other)
+      {
+         if (ReferenceEquals(_key, other._key))
+         {
+            return true;
+         }
+         if (_key == null || other._key == null)
+         {
+            return false;
+         }
+
+         if (_key.Count != other._key.Count)
+         {
+            return false;
+         }
+
+         for (int i = 0; i < _key.Count; i++)
+         {
+            string a = _key[i];
+            string b = other._key[i];
+            if (string.CompareOrdinal(a,b) != 0)
+               return false;
+         }
+
+         return true;
+      }
+
+      public override int GetHashCode()
+      {
+         int hashCode = 0;
+         // ReSharper disable once LoopCanBeConvertedToQuery
+         // ReSharper disable once ForCanBeConvertedToForeach
+         for (int index = 0; index < _key.Count; index++)
+         {
+            string key = _key[index];
+            hashCode = (key.GetHashCode() * 397) ^ hashCode;
+         }
+         return hashCode;
+      }
+   }
+}

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Parquet.Data;
 using Parquet.File.Data;
 using Parquet.Thrift;
@@ -284,6 +283,8 @@ namespace Parquet.File
 
       class ThriftSchemaTree
       {
+         readonly Dictionary<SchemaElement, Node> _memoizedFindResults = new Dictionary<SchemaElement, Node>();
+         
          public class Node
          {
             public Thrift.SchemaElement element;
@@ -303,7 +304,13 @@ namespace Parquet.File
 
          public Node Find(Thrift.SchemaElement tse)
          {
-            return Find(root, tse);
+            if (_memoizedFindResults.TryGetValue(tse, out Node node))
+            {
+               return node;
+            }
+            node = Find(root, tse);
+            _memoizedFindResults.Add(tse, node);
+            return node;
          }
 
          private Node Find(Node root, Thrift.SchemaElement tse)

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -11,10 +11,12 @@ namespace Parquet.File
    class ThriftFooter
    {
       private readonly Thrift.FileMetaData _fileMeta;
+      private readonly ThriftSchemaTree _tree;
 
       public ThriftFooter(Thrift.FileMetaData fileMeta)
       {
          _fileMeta = fileMeta ?? throw new ArgumentNullException(nameof(fileMeta));
+         _tree = new ThriftSchemaTree(_fileMeta.Schema);
       }
 
       public ThriftFooter(Schema schema, long totalRowCount)
@@ -28,6 +30,7 @@ namespace Parquet.File
          _fileMeta.Num_rows = totalRowCount;
 
          _fileMeta.Created_by = $"Parquet.Net version %Version% (build %Git.LongCommitHash%)";
+         _tree = new ThriftSchemaTree(_fileMeta.Schema);
       }
 
       public Dictionary<string, string> CustomMetadata
@@ -84,10 +87,9 @@ namespace Parquet.File
 
       public List<string> GetPath(Thrift.SchemaElement schemaElement)
       {
-         var tree = new ThriftSchemaTree(_fileMeta.Schema);
          var path = new List<string>();
 
-         ThriftSchemaTree.Node wrapped = tree.Find(schemaElement);
+         ThriftSchemaTree.Node wrapped = _tree.Find(schemaElement);
          while(wrapped.parent != null)
          {
             path.Add(wrapped.element.Name);

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using Parquet.Data;
 using Parquet.File.Data;
+using Parquet.Thrift;
 
 namespace Parquet.File
 {
@@ -107,14 +108,16 @@ namespace Parquet.File
 
          int i = 0;
          List<string> path = columnChunk.Meta_data.Path_in_schema;
+         int fieldCount = _fileMeta.Schema.Count;
 
          foreach (string pp in path)
          {
-            while(i < _fileMeta.Schema.Count)
+            while(i < fieldCount)
             {
-               if(_fileMeta.Schema[i].Name == pp)
+               SchemaElement schemaElement = _fileMeta.Schema[i];
+               if(string.CompareOrdinal(schemaElement.Name, pp) == 0)
                {
-                  Thrift.SchemaElement se = _fileMeta.Schema[i];
+                  Thrift.SchemaElement se = schemaElement;
 
                   bool repeated = (se.__isset.repetition_type && se.Repetition_type == Thrift.FieldRepetitionType.REPEATED);
                   bool defined = (se.Repetition_type == Thrift.FieldRepetitionType.REQUIRED);


### PR DESCRIPTION
### Fixes

Issue #84 

### Description

Before these changes the use case took 107,716ms to complete.  After each of these changes the time is 10,232ms.
**Note** The total time is the end-to-end test, now Parquet.net is a small part of the overhead of the conversion algorithm, where before it was the majority of the time. 

This screen shot shows the performance after all the refactoring.
![image](https://user-images.githubusercontent.com/278561/96676014-34771500-1321-11eb-90ce-0d0a6989b7fe.png)


**Reuse `ThriftSchemaTree` to reduce GC overhead.**

![image](https://user-images.githubusercontent.com/278561/96674573-f5939000-131d-11eb-94e1-3a8796988b41.png)

To resolve this I construct the `ThriftSchemaTree` in the `ThriftFooter` so it doesn't need to be created for each call to `GetPath`.  The impact of this change is shown here:

![image](https://user-images.githubusercontent.com/278561/96674678-2e336980-131e-11eb-91ba-0abe2216b942.png)

**Introduce ArrayView**

1. Remove the LINQ multiple enumerations of the data and overhead associated with allocations of LINQ Count used to allocate the new array allocated in PackDefinitions.
1. Reduce GC overhead by renting the Array underpinning the ArrayView for the new array allocated to hold the values from Pack Definitions, which is consistent with definition levels.
1. Do not add additional enumerations for computing statistics, most notably the distinct values.  The implementation of distinct values is based on the LINQ Distinct implementation, but uses the HashSet not the lightweight internal Set used by LINQ.  The benefit of this is in Net Core 2.1 the HashSet is able to be initialized with a capacity, which has a decent impact thanks to no resizing.

![image](https://user-images.githubusercontent.com/278561/96674809-6e92e780-131e-11eb-8550-9543d9b7df55.png)

**Optimize string comparison**

There were various places where string comparisons were used (e.g. in the Distinct operation and min/max values when computing statistics), which benefit from the faster `CompareOrdinal` implementation.

**Memoize `ThriftSchemaTree.Find`**

This was called a fair amount via GetPath and the benefit is shown below:

![image](https://user-images.githubusercontent.com/278561/96675745-75225e80-1320-11eb-8fa3-e8a9c0f7322a.png)

**Memoize `ThriftFooter.GetLevels`**

This was also on the hot path, benefit shown below:
![image](https://user-images.githubusercontent.com/278561/96675827-b581dc80-1320-11eb-9af8-829ed6e560ea.png)

GetLevels is also faster based on a more optimal algorithm, you'll see that change in an earlty commit before I introduced the memoization.
