### PR TITLE
Issues/77 serialized append

### DIFF
--- a/src/Parquet/ParquetConvert.cs
+++ b/src/Parquet/ParquetConvert.cs
@@ -25,11 +25,13 @@ namespace Parquet
       /// </param>
       /// <param name="compressionMethod"><see cref="CompressionMethod"/></param>
       /// <param name="rowGroupSize"></param>
+      /// <param name="append"></param>
       /// <returns></returns>
       public static Schema Serialize<T>(IEnumerable<T> objectInstances, Stream destination,
          Schema schema = null,
          CompressionMethod compressionMethod = CompressionMethod.Snappy,
-         int rowGroupSize = 5000)
+         int rowGroupSize = 5000,
+         bool append = false)
          where T : new()
       {
          if (objectInstances == null) throw new ArgumentNullException(nameof(objectInstances));
@@ -42,7 +44,7 @@ namespace Parquet
             schema = SchemaReflector.Reflect<T>();
          }
 
-         using (var writer = new ParquetWriter(schema, destination))
+         using (var writer = new ParquetWriter(schema, destination, append: append))
          {
             writer.CompressionMethod = compressionMethod;
 
@@ -80,15 +82,19 @@ namespace Parquet
       /// written to the stream. If you want to write only a subset of class properties please specify the schema yourself.
       /// </param>
       /// <param name="compressionMethod"><see cref="CompressionMethod"/></param>
+      /// <param name="rowGroupSize"></param>
+      /// <param name="append"></param>
       /// <returns></returns>
       public static Schema Serialize<T>(IEnumerable<T> objectInstances, string filePath,
          Schema schema = null,
-         CompressionMethod compressionMethod = CompressionMethod.Snappy)
+         CompressionMethod compressionMethod = CompressionMethod.Snappy,
+         int rowGroupSize = 5000,
+         bool append = false)
          where T : new()
       {
          using (Stream destination = System.IO.File.Create(filePath))
          {
-            return Serialize(objectInstances, destination, schema, compressionMethod);
+            return Serialize(objectInstances, destination, schema, compressionMethod, rowGroupSize, append);
          }
       }
 


### PR DESCRIPTION
### Fixes

Issue #77 

### Description

- Added new parameter `append` to `ParquetConvert.Serialization` for serialization to stream
- Added new parameters `rowGroupSize` and `append` to `ParquetConvert.Serialization` for serialization to file
- Added test method for `ParquetConvert.Serialization` with `append: true`

- [x] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->