### PR TITLE
Fix RunLengthBitPackingHybridValuesReader.ReadBitpacked. Fix #81

### DIFF
--- a/src/Parquet/File/Values/RunLengthBitPackingHybridValuesReader.cs
+++ b/src/Parquet/File/Values/RunLengthBitPackingHybridValuesReader.cs
@@ -108,7 +108,7 @@ namespace Parquet.File.Values
          int mask = MaskForBits(bitWidth);
 
          int i = 0;
-         int b = rawBytes[i];
+         uint b = rawBytes[i];
          int total = byteCount * 8;
          int bwl = 8;
          int bwr = 0;
@@ -122,7 +122,7 @@ namespace Parquet.File.Values
             }
             else if (bwl - bwr >= bitWidth)
             {
-               int r = ((b >> bwr) & mask);
+               int r = (int)((b >> bwr) & mask);
                total -= bitWidth;
                bwr += bitWidth;
 
@@ -131,7 +131,7 @@ namespace Parquet.File.Values
             else if (i + 1 < byteCount)
             {
                i += 1;
-               b |= (rawBytes[i] << bwl);
+               b |= (uint)(rawBytes[i] << bwl);
                bwl += 8;
             }
          }


### PR DESCRIPTION
### Fixes

Fix #81

### Description

The method that reads from bit packed data, RunLengthBitPackingHybridValuesReader.ReadBitpacked, was incorrectly using arithmetic shift instead of logical shift. Causing data corruption when the accumulator variable is greater than int.MaxValue.

This change is critical, please double check my changes

- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [ ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->