### PR TITLE
Fix reading of plain dictionary with zero length

### DIFF
--- a/src/Parquet/File/DataColumnReader.cs
+++ b/src/Parquet/File/DataColumnReader.cs
@@ -265,8 +265,10 @@ namespace Parquet.File
          int start = offset;
          int bitWidth = reader.ReadByte();
 
+         int length = GetRemainingLength(reader);
+
          //when bit width is zero reader must stop and just repeat zero maxValue number of times
-         if (bitWidth == 0)
+         if (bitWidth == 0 || length == 0)
          {
             for (int i = 0; i < maxReadCount; i++)
             {
@@ -275,7 +277,6 @@ namespace Parquet.File
          }
          else
          {
-            int length = GetRemainingLength(reader);
             offset += RunLengthBitPackingHybridValuesReader.ReadRleBitpackedHybrid(reader, bitWidth, length, dest, offset, maxReadCount);
          }
 


### PR DESCRIPTION
Sometimes parquet files generated by spark contain a page full of nulls. These pages have zero size and parquet.net fails with System.IO.EndOfStreamException.

The ReadRleBitpackedHybrid function interprets zero length as an instruction to read the actual length from the stream. ReadLevels relies on this behavior, however, zero can be a valid length when reading a plain dictionary page.

I decided not to mess with ReadRleBitpackedHybrid implementation and instead check that length is zero and skip the remaining items