### PR TITLE
Add support for decimal scale and precision

### DIFF
--- a/src/Parquet/Attributes/ParquetColumnAttribute.cs
+++ b/src/Parquet/Attributes/ParquetColumnAttribute.cs
@@ -40,5 +40,20 @@ namespace Parquet.Attributes
       /// DateTimeFormat. Impala or DateAndTime or Date
       /// </summary>
       public DateTimeFormat DateTimeFormat { get; set; }
+
+      /// <summary>
+      /// Precision for decimal fields
+      /// </summary>
+      public int DecimalPrecision { get; set; }
+
+      /// <summary>
+      /// Scale for decimal fields
+      /// </summary>
+      public int DecimalScale { get; set; }
+
+      /// <summary>
+      /// Should this decimal field force byte array encoding?
+      /// </summary>
+      public bool DecimalForceByteArrayEncoding { get; set; }
    }
 }

--- a/src/Parquet/Serialization/SchemaReflector.cs
+++ b/src/Parquet/Serialization/SchemaReflector.cs
@@ -84,6 +84,8 @@ namespace Parquet.Serialization
                r = new TimeSpanDataField(r.Name, columnAttr.TimeSpanFormat, r.HasNulls, r.IsArray);
             if (handler.ClrType == typeof(DateTime) || handler.ClrType == typeof(DateTimeOffset))
                r = new DateTimeDataField(r.Name, columnAttr.DateTimeFormat, r.HasNulls, r.IsArray);
+            if (handler.ClrType == typeof(decimal))
+               r = new DecimalDataField(r.Name, columnAttr.DecimalPrecision, columnAttr.DecimalScale, columnAttr.DecimalForceByteArrayEncoding, r.HasNulls, r.IsArray);
          }
 
          r.ClrPropName = property.Name;


### PR DESCRIPTION
### Fixes

default scale and precision is used for decimals

Issue #

### Description

I followed the same methodology used for DateTime

- [ ] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->