### PR TITLE
Preserve ticks during the conversion from NanoTime to DateTimeOffset

### DIFF
--- a/src/Parquet.Test/File/Values/Primitives/NanoTimeTest.cs
+++ b/src/Parquet.Test/File/Values/Primitives/NanoTimeTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Parquet.File.Values.Primitives;
+using Xunit;
+
+namespace Parquet.Test.File.Values.Primitives
+{
+   public class NanoTimeTest
+   {
+      [Fact]
+      public void ConvertToDateTimeOffset_PreservesTicks()
+      {
+         var dto = new DateTimeOffset(2021, 05, 14, 17, 52, 31, TimeSpan.Zero);
+         dto = dto.Add(TimeSpan.FromTicks(1234567));
+         var nanoTime = new NanoTime(dto);
+         var convertedDto = (DateTimeOffset) nanoTime;
+
+         Assert.Equal(dto, convertedDto);
+      }
+   }
+}

--- a/src/Parquet/File/Values/Primitives/NanoTime.cs
+++ b/src/Parquet/File/Values/Primitives/NanoTime.cs
@@ -50,12 +50,12 @@ namespace Parquet.File.Values.Primitives
          int Month = (int)(J + 2 - 12 * L);
          int Year = (int)(100 * (N - 49) + I + L);
 
-         double ms = nanoTime._timeOfDayNanos / 1000000D;
+         long timeOfDayTicks = nanoTime._timeOfDayNanos / 100;
 
          var result = new DateTimeOffset(Year, Month, Day,
             0, 0, 0,
             TimeSpan.Zero);
-         result = result.AddMilliseconds(ms);
+         result = result.AddTicks(timeOfDayTicks);
 
          return result;
       }


### PR DESCRIPTION
### Fixes

Issue #111 

### Description

Replace AddMilliseconds by AddTicks method to preserve ticks during the conversion from NanoTime to DateTimeOffset.