### PR TITLE
Enable support for nullable Boolean

### DIFF
--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -68,7 +68,7 @@ namespace Parquet.Data
       /// <summary>
       /// Data field
       /// </summary>
-      public DataField Field { get; private set; }
+      public DataField Field { get; set; }
 
       /// <summary>
       /// When true, this field has repetitions. It doesn't mean that it's an array though. This property simply checks that

--- a/src/Parquet/Data/Schema/DataField.cs
+++ b/src/Parquet/Data/Schema/DataField.cs
@@ -32,7 +32,7 @@ namespace Parquet.Data
       /// <summary>
       /// Unsupported, use at your own risk!
       /// </summary>
-      public Type ClrNullableIfHasNullsType { get; private set; }
+      public Type ClrNullableIfHasNullsType { get; set; }
 
       /// <summary>
       /// Creates a new instance of <see cref="DataField"/> by name and CLR type.

--- a/src/Parquet/File/DataColumnReader.cs
+++ b/src/Parquet/File/DataColumnReader.cs
@@ -127,6 +127,13 @@ namespace Parquet.File
                _dataTypeHandler.PlainDecode(_thriftSchemaElement, _thriftColumnChunk.Meta_data.Statistics.Max_value));
          }
 
+         // Fix for nullable booleans
+         if (finalColumn.Data.GetType().GetElementType() == typeof(Boolean?))
+         {
+            finalColumn.Field.ClrNullableIfHasNullsType = DataTypeFactory.Match(finalColumn.Field.DataType).ClrType.GetNullable();
+            _dataField.ClrNullableIfHasNullsType = DataTypeFactory.Match(finalColumn.Field.DataType).ClrType.GetNullable();
+         }
+
          return finalColumn;
       }
 

--- a/src/Parquet/Serialization/Values/ClrBridge.cs
+++ b/src/Parquet/Serialization/Values/ClrBridge.cs
@@ -11,7 +11,7 @@ namespace Parquet.Serialization.Values
    {
       private readonly Type _classType;
       private static readonly ConcurrentDictionary<TypeCachingKey, MSILGenerator.PopulateListDelegate> _collectorKeyToTag = new ConcurrentDictionary<TypeCachingKey, MSILGenerator.PopulateListDelegate>();
-      private static readonly ConcurrentDictionary<TypeCachingKey, MSILGenerator.AssignArrayDelegate> _assignerKeyToTag = new ConcurrentDictionary<TypeCachingKey, MSILGenerator.AssignArrayDelegate>();
+      //private static readonly ConcurrentDictionary<TypeCachingKey, MSILGenerator.AssignArrayDelegate> _assignerKeyToTag = new ConcurrentDictionary<TypeCachingKey, MSILGenerator.AssignArrayDelegate>();
 
       public ClrBridge(Type classType)
       {
@@ -37,7 +37,7 @@ namespace Parquet.Serialization.Values
       public void AssignColumn(DataColumn dataColumn, Array classInstances)
       {
          var key = new TypeCachingKey(_classType, dataColumn.Field);
-         MSILGenerator.AssignArrayDelegate assignColumn = _assignerKeyToTag.GetOrAdd(key, (_) => new MSILGenerator().GenerateAssigner(dataColumn, _classType));
+         MSILGenerator.AssignArrayDelegate assignColumn = new MSILGenerator().GenerateAssigner(dataColumn, _classType);
          assignColumn(dataColumn, classInstances);
       }
    }

--- a/src/Parquet/Serialization/Values/MSILGenerator.cs
+++ b/src/Parquet/Serialization/Values/MSILGenerator.cs
@@ -18,6 +18,7 @@ namespace Parquet.Serialization.Values
          DateTimeOffsetToDateTimeConversion.Instance,
          NullableDateTimeToDateTimeOffsetConversion.Instance,
          NullableDateTimeOffsetToDateTimeConversion.Instance,
+         NullableBooleanToBooleanConversion.Instance
       };
 
       public delegate object PopulateListDelegate(object instances,
@@ -139,9 +140,7 @@ namespace Parquet.Serialization.Values
 
       public AssignArrayDelegate GenerateAssigner(DataColumn dataColumn, Type classType)
       {
-         DataField fileField = dataColumn.Field;
-         Schema typeSchema = SchemaReflector.Reflect(classType);
-         DataField typeField = typeSchema.FindDataField(fileField.Path);
+         DataField typeField = dataColumn.Field;
 
          Type[] methodArgs = { typeof(DataColumn), typeof(Array) };
          var runMethod = new DynamicMethod(
@@ -321,6 +320,18 @@ namespace Parquet.Serialization.Values
             il.Emit(OpCodes.Call, method);
          }
       }
+
+      sealed class NullableBooleanToBooleanConversion : TypeConversion<Boolean?, Boolean>
+      {
+         public static readonly TypeConversion<Boolean?, Boolean> Instance = new NullableBooleanToBooleanConversion();
+
+         private static readonly MethodInfo method = typeof(ConversionHelpers).GetTypeInfo().GetDeclaredMethod("NullableBooleanToBooleanConversion");
+
+         public override void Emit(ILGenerator il)
+         {
+            il.Emit(OpCodes.Call, method);
+         }
+      }
    }
 
    /// <summary>
@@ -357,6 +368,18 @@ namespace Parquet.Serialization.Values
       {
          if (value == null) { return null; }
          return new DateTimeOffset(value.Value);
+      }
+
+      /// <summary>
+      /// Convert Boolean? to Boolean
+      /// </summary>
+      /// <param name="value">Boolean?</param>
+      /// <returns>Boolean</returns>
+      public static Boolean NullableBooleanToBooleanConversion(Boolean? value)
+      {
+         if (!value.HasValue) { return false; }
+         return value.Value;
+
       }
    }
 }


### PR DESCRIPTION
### Fixes

Issue when Deserializing a file that has been saved with Python or C# including a nullable Boolean.
Before, it was mapped to wrong output (False -> True, True -> False) when Deserializing (in the generic IL code).

I am certain that the fix is not ready to be merged in current state, but wanted to raise PR to get awareness on issue,
and work with you to make the perfect fix.
The code in the current state maps correctly for both nullable and not nullable booleans:
Nullable Null -> False
Nullable True -> True
Nullable False -> False
False -> False
True -> True

### Description

* Inclusion of a NullableBooleanToBoolean converter.
* When detecting that data is in fact Nullable Boolean, change the CLR type on DataField (required making setter public)
* When invokink GenerateAssigner, use DataField definition saved on DataColumn instead of cashed version, which will be wrong for columns with Nullable Booleans

- [ No] I have included unit tests validating this fix.
- [ No] I have updated markdown documentation where required.
- [ Yes] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->