### PR TITLE
 Fix for NullReference-Exception in case of Int16, UnsignedShort and UnsignedByte

### DIFF
--- a/src/Parquet.Test/DataFieldTypeCoverageTests.cs
+++ b/src/Parquet.Test/DataFieldTypeCoverageTests.cs
@@ -1,0 +1,49 @@
+﻿using Parquet.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using Parquet.File.Values.Primitives;
+using NetBox.Extensions;
+using System.Linq;
+
+namespace Parquet.Test
+{
+   public class DataFieldTypeCoverageTests : TestBase
+   {
+      /// <summary>
+      /// Checking if all <see cref="DataField"/> objects contstructed
+      /// via the <see cref="DataField.DataField(string, DataType, bool, bool)"/>
+      /// constructor contain non-null values for <see cref="DataField.ClrType"/>
+      /// and <see cref="DataField.ClrNullableIfHasNullsType"/>.
+      /// </summary>
+      /// <param name="type"></param>
+      [Theory]
+      [InlineData(DataType.Boolean)]
+      [InlineData(DataType.Byte)]
+      [InlineData(DataType.ByteArray)]
+      [InlineData(DataType.DateTimeOffset)]
+      [InlineData(DataType.Decimal)]
+      [InlineData(DataType.Double)]
+      [InlineData(DataType.Float)]
+      [InlineData(DataType.Int16)]
+      [InlineData(DataType.Int32)]
+      [InlineData(DataType.Int64)]
+      [InlineData(DataType.Int96)]
+      [InlineData(DataType.Interval)]
+      [InlineData(DataType.Short)]
+      [InlineData(DataType.SignedByte)]
+      [InlineData(DataType.String)]
+      [InlineData(DataType.UnsignedByte)]
+      [InlineData(DataType.UnsignedInt16)]
+      [InlineData(DataType.UnsignedShort)]
+      public void CheckingForClrType(DataType type)
+      {
+         DataField input = new DataField(type.ToString(), type);
+
+         Assert.NotNull(input.ClrType);
+         Assert.NotNull(input.ClrNullableIfHasNullsType);
+      }
+   }
+}

--- a/src/Parquet/Data/Concrete/Int16DataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/Int16DataTypeHandler.cs
@@ -13,12 +13,12 @@ namespace Parquet.Data.Concrete
 
       protected override short ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadInt16();
+         return (short)reader.ReadInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, short value)
       {
-         writer.Write(value);
+         writer.Write((int)value);
       }
    }
 }

--- a/src/Parquet/Data/Concrete/Int16DataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/Int16DataTypeHandler.cs
@@ -13,12 +13,12 @@ namespace Parquet.Data.Concrete
 
       protected override short ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return (short)reader.ReadInt32();
+         return (short) reader.ReadInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, short value)
       {
-         writer.Write((int)value);
+         writer.Write((int) value);
       }
    }
 }

--- a/src/Parquet/Data/Concrete/ShortDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/ShortDataTypeHandler.cs
@@ -4,9 +4,9 @@ using Parquet.Data;
 
 namespace Parquet.Data.Concrete
 {
-   class Int16DataTypeHandler : BasicPrimitiveDataTypeHandler<Int16>
+   class ShortDataTypeHandler : BasicPrimitiveDataTypeHandler<short>
    {
-      public Int16DataTypeHandler() : base(DataType.Int16, Thrift.Type.INT32, Thrift.ConvertedType.INT_16)
+      public ShortDataTypeHandler() : base(DataType.Short, Thrift.Type.INT32, Thrift.ConvertedType.INT_16)
       {
 
       }

--- a/src/Parquet/Data/Concrete/ShortDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/ShortDataTypeHandler.cs
@@ -13,12 +13,12 @@ namespace Parquet.Data.Concrete
 
       protected override short ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadInt16();
+         return (short)reader.ReadInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, short value)
       {
-         writer.Write(value);
+         writer.Write((int)value);
       }
    }
 }

--- a/src/Parquet/Data/Concrete/UnsignedByteDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/UnsignedByteDataTypeHandler.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Parquet.Data;
+
+namespace Parquet.Data.Concrete
+{
+   class UnsignedByteDataTypeHandler : BasicPrimitiveDataTypeHandler<byte>
+   {
+      public UnsignedByteDataTypeHandler() : base(DataType.UnsignedByte, Thrift.Type.INT32, Thrift.ConvertedType.UINT_8)
+      {
+
+      }
+
+      protected override byte ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
+      {
+         return reader.ReadByte();
+      }
+
+      protected override void WriteOne(BinaryWriter writer, byte value)
+      {
+         writer.Write(value);
+      }
+   }
+}
+

--- a/src/Parquet/Data/Concrete/UnsignedByteDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/UnsignedByteDataTypeHandler.cs
@@ -16,13 +16,12 @@ namespace Parquet.Data.Concrete
 
       protected override byte ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadByte();
+         return (byte)reader.ReadInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, byte value)
       {
-         writer.Write(value);
+         writer.Write((int)value);
       }
    }
 }
-

--- a/src/Parquet/Data/Concrete/UnsignedInt16DataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/UnsignedInt16DataTypeHandler.cs
@@ -12,12 +12,12 @@ namespace Parquet.Data.Concrete
 
       protected override ushort ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadUInt16();
+         return (ushort)reader.ReadUInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, ushort value)
       {
-         writer.Write(value);
+         writer.Write((int)value);
       }
    }
 }

--- a/src/Parquet/Data/Concrete/UnsignedInt16DataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/UnsignedInt16DataTypeHandler.cs
@@ -12,12 +12,12 @@ namespace Parquet.Data.Concrete
 
       protected override ushort ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return (ushort)reader.ReadUInt32();
+         return (ushort) reader.ReadUInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, ushort value)
       {
-         writer.Write((int)value);
+         writer.Write((int) value);
       }
    }
 }

--- a/src/Parquet/Data/Concrete/UnsignedShortDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/UnsignedShortDataTypeHandler.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace Parquet.Data.Concrete
 {
-   class UnsignedInt16DataTypeHandler : BasicPrimitiveDataTypeHandler<UInt16>
+   class UnsignedShortDataTypeHandler : BasicPrimitiveDataTypeHandler<ushort>
    {
-      public UnsignedInt16DataTypeHandler() : base(DataType.UnsignedInt16, Thrift.Type.INT32, Thrift.ConvertedType.UINT_16)
+      public UnsignedShortDataTypeHandler() : base(DataType.UnsignedShort, Thrift.Type.INT32, Thrift.ConvertedType.UINT_16)
       {
 
       }

--- a/src/Parquet/Data/Concrete/UnsignedShortDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/UnsignedShortDataTypeHandler.cs
@@ -11,12 +11,12 @@ namespace Parquet.Data.Concrete
 
       protected override ushort ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         return reader.ReadUInt16();
+         return (ushort)reader.ReadUInt32();
       }
 
       protected override void WriteOne(BinaryWriter writer, ushort value)
       {
-         writer.Write(value);
+         writer.Write((int)value);
       }
    }
 }

--- a/src/Parquet/Data/DataTypeFactory.cs
+++ b/src/Parquet/Data/DataTypeFactory.cs
@@ -19,7 +19,10 @@ namespace Parquet.Data
          // low priority types
          new BooleanDataTypeHandler(),
          new ByteDataTypeHandler(),
+         new UnsignedByteDataTypeHandler(),
          new SignedByteDataTypeHandler(),
+         new ShortDataTypeHandler(),
+         new UnsignedShortDataTypeHandler(),
          new Int16DataTypeHandler(),
          new UnsignedInt16DataTypeHandler(),
          new UnsignedInt32DataTypeHandler(),


### PR DESCRIPTION
Copy of https://github.com/elastacloud/parquet-dotnet/pull/488

Adds/corrects the `DataType` to `BasicPrimitiveDataTypeHandler` mapping, solving the NullReference-Exception bug.

### Fixes

Issue #114

### Description

Not all values of the `DataType` enum had mappings to appropriate instances of `BasicPrimitiveDataTypeHandler` in `DataTypeFactory`, which I believe caused the unmatched types to be resolved to default objects in `_allDataTypes.FirstOrDefault(dt => dt.DataType == dataType)`, and that caused some of the fields of the `DataType` object to be null.

This PR adds and corrects `BasicPrimitiveDataTypeHandler`s so that every value of the `DataType` enum is mapped to an appropriate handler, solving the NullReference-Exception bug.

Fix is accompanied with a unit test which shows that objects created from all values of the `DataType` enum (except the `Unspecified` value) have a non-null `ClrType` field.

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->