### PR TITLE
Fix: Issue with concurrent writing of string fields

### DIFF
--- a/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
@@ -7,11 +7,9 @@ namespace Parquet.Data.Concrete
 {
    class StringDataTypeHandler : BasicDataTypeHandler<string>
    {
-      private static readonly UTF8Encoding E = new UTF8Encoding();
+      private static readonly Encoding E = Encoding.UTF8;
       private static readonly ArrayPool<byte> _bytePool = ArrayPool<byte>.Shared;
       private static readonly ArrayPool<string> _stringPool = ArrayPool<string>.Shared;
-
-      private static byte[] _encodingBuf;
       
       public StringDataTypeHandler() : base(DataType.String, Thrift.Type.BYTE_ARRAY, Thrift.ConvertedType.UTF8)
       {
@@ -118,26 +116,12 @@ namespace Parquet.Data.Concrete
          else
          {
             //transofrm to byte array first, as we need the length of the byte buffer, not string length
-
-            int needLength = value.Length * 3;
-            if(_encodingBuf == null || _encodingBuf.Length < needLength)
-            {
-               if(_encodingBuf != null)
-               {
-                  _bytePool.Return(_encodingBuf);
-               }
-
-               _encodingBuf = _bytePool.Rent(needLength);
-            }
-
-            // this can write directly to buffer after I kill binarystream
-            int bytesWritten = E.GetBytes(value, 0, value.Length, _encodingBuf, 0);
-
+            byte[] data = E.GetBytes(value);
             if (includeLengthPrefix)
             {
-               writer.Write(bytesWritten);
+               writer.Write(data.Length);
             }
-            writer.Write(_encodingBuf, 0, bytesWritten);
+            writer.Write(data);
          }
       }
 


### PR DESCRIPTION
### Fixes

The 3.9.0 release introduced an issue with writing parquet files in parallel, where string field data would get mixed up with other string fields.

### Description

The issue has been reproduced by the `Flat_concurrent_write_read` unit test, and the cause has been identified as the latest changes to the `StringDataTypeHandler` where a static string buffer was introduced.

The suggested change is to revert the changes to `StringDataTypeHandler`.

- [x] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->