### PR TITLE
Remove HasValueFlags array.

### DIFF
--- a/src/Parquet/Data/BasicDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicDataTypeHandler.cs
@@ -120,7 +120,7 @@ namespace Parquet.Data
 
       public abstract ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount);
 
-      public abstract Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags);
+      public abstract Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel);
 
       protected ArrayView PackDefinitions<TNullable>(TNullable[] data, int maxDefinitionLevel, out int[] definitionLevels, out int definitionsLength, out int nullCount)
          where TNullable : class
@@ -151,10 +151,9 @@ namespace Parquet.Data
          return result;
       }
 
-      protected T[] UnpackGenericDefinitions<T>(T[] src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)
+      protected T[] UnpackGenericDefinitions<T>(T[] src, int[] definitionLevels, int maxDefinitionLevel)
       {
          T[] result = (T[])GetArray(definitionLevels.Length, false, true);
-         hasValueFlags = new bool[definitionLevels.Length];
 
          int isrc = 0;
          for (int i = 0; i < definitionLevels.Length; i++)

--- a/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
@@ -41,15 +41,14 @@ namespace Parquet.Data
          return PackDefinitions((TSystemType?[])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }
 
-      public override Array UnpackDefinitions(Array untypedSource, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)
+      public override Array UnpackDefinitions(Array untypedSource, int[] definitionLevels, int maxDefinitionLevel)
       {
-         return UnpackDefinitions((TSystemType[])untypedSource, definitionLevels, maxDefinitionLevel, out hasValueFlags);
+         return UnpackDefinitions((TSystemType[])untypedSource, definitionLevels, maxDefinitionLevel);
       }
 
-      private TSystemType?[] UnpackDefinitions(TSystemType[] src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)
+      private TSystemType?[] UnpackDefinitions(TSystemType[] src, int[] definitionLevels, int maxDefinitionLevel)
       {
          TSystemType?[] result = (TSystemType?[])GetArray(definitionLevels.Length, false, true);
-         hasValueFlags = new bool[definitionLevels.Length];
 
          int isrc = 0;
          for (int i = 0; i < definitionLevels.Length; i++)
@@ -59,17 +58,9 @@ namespace Parquet.Data
             if (level == maxDefinitionLevel)
             {
                result[i] = src[isrc++];
-               hasValueFlags[i] = true;
             }
-            else if(level == 0)
-            {
-               hasValueFlags[i] = true;
-            }
-
          }
-
          return result;
-
       }
 
       private ArrayView PackDefinitions(TSystemType?[] data, int maxDefinitionLevel, out int[] definitionLevels, out int definitionsLength, out int nullCount)

--- a/src/Parquet/Data/Concrete/ByteArrayDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/ByteArrayDataTypeHandler.cs
@@ -78,9 +78,9 @@ namespace Parquet.Data.Concrete
          return PackDefinitions((byte[][])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }
 
-      public override Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)
+      public override Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel)
       {
-         return UnpackGenericDefinitions((byte[][])src, definitionLevels, maxDefinitionLevel, out hasValueFlags);
+         return UnpackGenericDefinitions((byte[][])src, definitionLevels, maxDefinitionLevel);
       }
 
       protected override void WriteOne(BinaryWriter writer, byte[] value)

--- a/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
@@ -99,9 +99,9 @@ namespace Parquet.Data.Concrete
          return PackDefinitions((string[])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }
 
-      public override Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)
+      public override Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel)
       {
-         return UnpackGenericDefinitions((string[])src, definitionLevels, maxDefinitionLevel, out hasValueFlags);
+         return UnpackGenericDefinitions((string[])src, definitionLevels, maxDefinitionLevel);
       }
 
       private static void WriteOne(BinaryWriter writer, string value, bool includeLengthPrefix)

--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -44,9 +44,7 @@ namespace Parquet.Data
          // 1. Apply definitions
          if (definitionLevels != null)
          {
-            bool[] hasValueFlags;
-            Data = _dataTypeHandler.UnpackDefinitions(Data, definitionLevels, maxDefinitionLevel, out hasValueFlags);
-            HasValueFlags = hasValueFlags;
+            Data = _dataTypeHandler.UnpackDefinitions(Data, definitionLevels, maxDefinitionLevel);
          }
 
          // 2. Apply repetitions
@@ -62,8 +60,6 @@ namespace Parquet.Data
       /// Repetition levels if any.
       /// </summary>
       public int[] RepetitionLevels { get; private set; }
-
-      internal bool[] HasValueFlags { get; set; }
 
       /// <summary>
       /// Data field

--- a/src/Parquet/Data/IDataTypeHandler.cs
+++ b/src/Parquet/Data/IDataTypeHandler.cs
@@ -50,7 +50,7 @@ namespace Parquet.Data
 
       ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount);
 
-      Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags);
+      Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel);
 
       byte[] PlainEncode(Thrift.SchemaElement tse, object x);
 

--- a/src/Parquet/Data/NonDataDataTypeHandler.cs
+++ b/src/Parquet/Data/NonDataDataTypeHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 
@@ -47,7 +46,7 @@ namespace Parquet.Data
          throw new NotImplementedException();
       }
 
-      public Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)
+      public Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel)
       {
          throw new NotSupportedException();
       }


### PR DESCRIPTION
I was working on creating a DbDataReader implementation over the ParquetReader, and this internal `HasValueFlags` array was confusing me. I assumed that it indicated whether the field was null or not, but upon further investigation it appears to be completely unused. After deleting it entirely, all tests still pass. At a minimum, getting rid of this would be a minor perf and memory use win, but culling it will also avoid future developer confusion.