### PR TITLE
Fix breaking change in v3.9 due to missing default fallback for Decimal Precision/Scale

### DIFF
--- a/src/Parquet.Test/Serialisation/ParquetConvertTest.cs
+++ b/src/Parquet.Test/Serialisation/ParquetConvertTest.cs
@@ -149,7 +149,8 @@ namespace Parquet.Test.Serialisation
             .Select(i => new SimpleRenamed
             {
                Id = i,
-               PersonName = $"row {i}"
+               PersonName = $"row {i}",
+               NullableDecimal = (i % 3 == 0) ? null : (decimal)i / 3
             });
 
          using (var ms = new MemoryStream())
@@ -160,11 +161,17 @@ namespace Parquet.Test.Serialisation
 
             SimpleRenamed[] structures2 = ParquetConvert.Deserialize<SimpleRenamed>(ms);
 
+            var formatDecimal = new Func<decimal?, decimal?>(d => d.HasValue
+               ? Math.Round(d.Value, 18, MidpointRounding.ToZero)
+               : d
+            );
+
             SimpleRenamed[] structuresArray = structures.ToArray();
             for (int i = 0; i < 10; i++)
             {
                Assert.Equal(structuresArray[i].Id, structures2[i].Id);
                Assert.Equal(structuresArray[i].PersonName, structures2[i].PersonName);
+               Assert.Equal(formatDecimal(structuresArray[i].NullableDecimal), formatDecimal(structures2[i].NullableDecimal));
             }
          }
       }
@@ -411,6 +418,10 @@ namespace Parquet.Test.Serialisation
 
          [ParquetColumn("Name")]
          public string PersonName { get; set; }
+
+         //Validate Backwards compatibility of default Decimal Precision and Scale values broken in v3.9.
+         [ParquetColumn("DecimalColumnRenamed")]
+         public decimal? NullableDecimal { get; set; }
       }
 
       public class StructureWithTestType<T>

--- a/src/Parquet/Attributes/ParquetColumnAttribute.cs
+++ b/src/Parquet/Attributes/ParquetColumnAttribute.cs
@@ -14,7 +14,8 @@ namespace Parquet.Attributes
       /// </summary>
       public ParquetColumnAttribute()
       {
-         //Make the Defaults Explicit (vs implicit by simply being the first Enum); this helps make the code easier to reason about decrease risk from future changes.
+         //Make the Defaults Explicit (vs implicit by simply being the first Enum); this helps make the code easier
+         // to reason about decrease risk from future changes.
          TimeSpanFormat = TimeSpanFormat.MilliSeconds;
          DateTimeFormat = DateTimeFormat.Impala;
 

--- a/src/Parquet/Attributes/ParquetColumnAttribute.cs
+++ b/src/Parquet/Attributes/ParquetColumnAttribute.cs
@@ -14,7 +14,7 @@ namespace Parquet.Attributes
       /// </summary>
       public ParquetColumnAttribute()
       {
-         //Make the Defaults Explicit (vs implicit by simply being the first Enum); this helps make hte code easier to reason about and less brittle.
+         //Make the Defaults Explicit (vs implicit by simply being the first Enum); this helps make the code easier to reason about decrease risk from future changes.
          TimeSpanFormat = TimeSpanFormat.MilliSeconds;
          DateTimeFormat = DateTimeFormat.Impala;
 
@@ -34,7 +34,7 @@ namespace Parquet.Attributes
       }
 
       /// <summary>
-      /// Column name. When undefined a default propety name is used which is simply the declared property name on the class.
+      /// Column name. When undefined a default property name is used which is simply the declared property name on the class.
       /// </summary>
       public string Name { get; set; }
 

--- a/src/Parquet/Attributes/ParquetColumnAttribute.cs
+++ b/src/Parquet/Attributes/ParquetColumnAttribute.cs
@@ -10,11 +10,17 @@ namespace Parquet.Attributes
    public class ParquetColumnAttribute : Attribute
    {
       /// <summary>
-      /// Creates a new instance of the attribute clas
+      /// Creates a new instance of the attribute class
       /// </summary>
       public ParquetColumnAttribute()
       {
+         //Make the Defaults Explicit (vs implicit by simply being the first Enum); this helps make hte code easier to reason about and less brittle.
+         TimeSpanFormat = TimeSpanFormat.MilliSeconds;
+         DateTimeFormat = DateTimeFormat.Impala;
 
+         //NOTE: We implement the original defaults from parquet-dotnet before release v3.9 to achieve proper backwards compatibility!
+         DecimalPrecision = DecimalFormatDefaults.DefaultPrecision;
+         DecimalScale = DecimalFormatDefaults.DefaultScale;
       }
 
       /// <summary>
@@ -22,6 +28,7 @@ namespace Parquet.Attributes
       /// </summary>
       /// <param name="name">Column name</param>
       public ParquetColumnAttribute(string name)
+         : this()
       {
          Name = name;
       }

--- a/src/Parquet/Data/Concrete/DecimalDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/DecimalDataTypeHandler.cs
@@ -58,8 +58,8 @@ namespace Parquet.Data.Concrete
          else
          {
             //set defaults
-            tse.Precision = 38;
-            tse.Scale = 18;
+            tse.Precision = DecimalFormatDefaults.DefaultPrecision;
+            tse.Scale = DecimalFormatDefaults.DefaultScale;
             tse.Type_length = 16;
          }
       }

--- a/src/Parquet/Data/DecimalFormatDefaults.cs
+++ b/src/Parquet/Data/DecimalFormatDefaults.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Parquet.Data
+{
+   /// <summary>
+   /// Pre-defined decimal handling default values; providing backwards compatibility prior to v3.9 where these were made configurable.
+   /// </summary>
+   public class DecimalFormatDefaults
+   {
+      /// <summary>
+      /// The Default Precision value used when not explicitly defined; this is the value used prior to parquet-dotnet v3.9.
+      /// </summary>
+      public const int DefaultPrecision = 38;
+      /// <summary>
+      /// The Default Scale value used when not explicitly defined; this is the value used prior to parquet-dotnet v3.9.
+      /// </summary>
+      public const int DefaultScale = 18;
+   }
+}


### PR DESCRIPTION
### Fixes

Issue #131 

### Description

Fix breaking changes from v3.9 whereby new support for explicitly controlling Decimal precision and scale did not include support for previously existing default values. The changes introduced no longer allowed existing code to use defaults that were originally supported prior to v3.9.  

This is easily resolved by ensuring that the new properties available on `ParquetColumnAttribute` to provide clear default values when not explicitly defined by consumers.

The use case here is when we merely want to rename a `decimal` column like any other column; therefore this is now covered by the unit test `Serialise_deserialise_renamed_column` test.  The `Serialise_deserialise_renamed_column` test now passes successfully; but was failing during serialization & de-serialization when test data was added to the model.

Also factored out the default values for Precision & Scale into a common place in `DecimalFormatDefaults` class the and updated `DecimalDataTypeHandler` to also reference these defaults to eliminate duplication.

- [X] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [X ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->