### PR TITLE
Fix Field equality in SchemaValidation inside ParquetWriter.

### DIFF
--- a/src/Parquet.Test/SchemaTest.cs
+++ b/src/Parquet.Test/SchemaTest.cs
@@ -3,7 +3,6 @@ using System;
 using Xunit;
 using System.Collections.Generic;
 using System.IO;
-using Parquet.Data.Rows;
 
 namespace Parquet.Test
 {

--- a/src/Parquet.Test/SchemaTest.cs
+++ b/src/Parquet.Test/SchemaTest.cs
@@ -3,6 +3,7 @@ using System;
 using Xunit;
 using System.Collections.Generic;
 using System.IO;
+using Parquet.Data.Rows;
 
 namespace Parquet.Test
 {
@@ -33,7 +34,7 @@ namespace Parquet.Test
       }
 
       [Fact]
-      public void Schemas_idential_equal()
+      public void Schemas_identical_equal()
       {
          var schema1 = new Schema(new DataField<int>("id"), new DataField<string>("city"));
          var schema2 = new Schema(new DataField<int>("id"), new DataField<string>("city"));

--- a/src/Parquet/Data/Schema/Schema.cs
+++ b/src/Parquet/Data/Schema/Schema.cs
@@ -149,8 +149,7 @@ namespace Parquet.Data
                || field.ClrPropName != otherField.ClrPropName
                || field.Path != otherField.Path
                || field.MaxDefinitionLevel != otherField.MaxDefinitionLevel
-               || field.MaxRepetitionLevel != otherField.MaxRepetitionLevel
-               )
+               || field.MaxRepetitionLevel != otherField.MaxRepetitionLevel)
             {
                return false;
             }

--- a/src/Parquet/Data/Schema/Schema.cs
+++ b/src/Parquet/Data/Schema/Schema.cs
@@ -48,7 +48,7 @@ namespace Parquet.Data
 
       private Schema(List<Field> fields)
       {
-         if(fields.Count == 0)
+         if (fields.Count == 0)
          {
             throw new ArgumentException("at least one field is required", nameof(fields));
          }
@@ -56,7 +56,7 @@ namespace Parquet.Data
          _fields = fields;
 
          //set levels now, after schema is constructeds
-         foreach(Field field in fields)
+         foreach (Field field in fields)
          {
             field.PropagateLevels(0, 0);
          }
@@ -109,7 +109,7 @@ namespace Parquet.Data
 
          void traverse(IEnumerable<Field> fields)
          {
-            foreach(Field f in fields)
+            foreach (Field f in fields)
             {
                analyse(f);
             }
@@ -139,9 +139,21 @@ namespace Parquet.Data
 
          if (_fields.Count != other._fields.Count) return false;
 
-         for(int i = 0; i < _fields.Count; i++)
+         for (int i = 0; i < _fields.Count; i++)
          {
-            if (!_fields[i].Equals(other._fields[i])) return false;
+            Field field = _fields[i];
+            Field otherField = other._fields[i];
+
+            if (field.Name != otherField.Name
+               || field.SchemaType != otherField.SchemaType
+               || field.ClrPropName != otherField.ClrPropName
+               || field.Path != otherField.Path
+               || field.MaxDefinitionLevel != otherField.MaxDefinitionLevel
+               || field.MaxRepetitionLevel != otherField.MaxRepetitionLevel
+               )
+            {
+               return false;
+            }
          }
 
          return true;
@@ -152,7 +164,7 @@ namespace Parquet.Data
       /// </summary>
       public string GetNotEqualsMessage(Schema other, string thisName, string otherName)
       {
-         if(_fields.Count != other._fields.Count)
+         if (_fields.Count != other._fields.Count)
          {
             return $"different number of elements ({_fields.Count} != {other._fields.Count})";
          }
@@ -162,7 +174,7 @@ namespace Parquet.Data
          {
             if (!_fields[i].Equals(other._fields[i]))
             {
-               if(sb.Length != 0)
+               if (sb.Length != 0)
                {
                   sb.Append(", ");
                }
@@ -196,7 +208,7 @@ namespace Parquet.Data
          if (ReferenceEquals(this, obj)) return true;
          if (obj.GetType() != GetType()) return false;
 
-         return Equals((Schema) obj);
+         return Equals((Schema)obj);
       }
 
       /// <summary>
@@ -211,6 +223,7 @@ namespace Parquet.Data
       }
 
       /// <summary>
+      /// Present the Schema in a human readable string format.
       /// </summary>
       public override string ToString()
       {


### PR DESCRIPTION
### Fixes

[Issue #134](https://github.com/aloneguid/parquet-dotnet/issues/134)

### Description

`System.Object.Equals()` equality should not be relied upon for two custom complex objects in C#.

This was further exacerbated because of type, nullable, and boxing.

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->