### PR TITLE
Accept offset and count on array parameters

### DIFF
--- a/src/Parquet.Test/ParquetWriterTest.cs
+++ b/src/Parquet.Test/ParquetWriterTest.cs
@@ -164,6 +164,60 @@ namespace Parquet.Test
       }
 
       [Fact]
+      public void Writes_only_beginning_of_array()
+      {
+         var ms = new MemoryStream();
+         var id = new DataField<int>("id");
+
+         //write
+         using (var writer = new ParquetWriter(new Schema(id), ms))
+         {
+            using (ParquetRowGroupWriter rg = writer.CreateRowGroup())
+            {
+               rg.WriteColumn(new DataColumn(id, new[] { 1, 2, 3, 4 }, 0, 3));
+            }
+         }
+
+         //read back
+         using (var reader = new ParquetReader(ms))
+         {
+            Assert.Equal(3, reader.ThriftMetadata.Num_rows);
+
+            using (ParquetRowGroupReader rg = reader.OpenRowGroupReader(0))
+            {
+               Assert.Equal(new int[] { 1, 2, 3 }, rg.ReadColumn(id).Data);
+            }
+         }
+      }
+
+      [Fact]
+      public void Writes_only_end_of_array()
+      {
+         var ms = new MemoryStream();
+         var id = new DataField<int>("id");
+
+         //write
+         using (var writer = new ParquetWriter(new Schema(id), ms))
+         {
+            using (ParquetRowGroupWriter rg = writer.CreateRowGroup())
+            {
+               rg.WriteColumn(new DataColumn(id, new[] { 1, 2, 3, 4 }, 1, 3));
+            }
+         }
+
+         //read back
+         using (var reader = new ParquetReader(ms))
+         {
+            Assert.Equal(3, reader.ThriftMetadata.Num_rows);
+
+            using (ParquetRowGroupReader rg = reader.OpenRowGroupReader(0))
+            {
+               Assert.Equal(new int[] { 2, 3, 4 }, rg.ReadColumn(id).Data);
+            }
+         }
+      }
+
+      [Fact]
       public void FileMetadata_sets_num_rows_on_file_and_row_group()
       {
          var ms = new MemoryStream();

--- a/src/Parquet/Data/ArrayView.cs
+++ b/src/Parquet/Data/ArrayView.cs
@@ -11,9 +11,10 @@ namespace Parquet.Data
       private readonly Array _array;
       private bool _consumed;
 
-      public ArrayView(Array array)
+      public ArrayView(Array array, int offset, int count)
       {
-         Count = array.Length;
+         Offset = offset;
+         Count = count;
          _array = array;
       }
 
@@ -24,6 +25,8 @@ namespace Parquet.Data
 
       public virtual int Count { get; }
 
+      public int Offset { get; }
+
       protected virtual void ReturnArray()
       {
       }
@@ -32,7 +35,7 @@ namespace Parquet.Data
       {
          AssertNotConsumed();
          T[] typed = (T[]) _array;
-         for (int i = 0; i < Count; i++)
+         for (int i = Offset; i < Offset+Count; i++)
          {
             yield return typed[i];
          }
@@ -47,7 +50,7 @@ namespace Parquet.Data
          T[] typed = (T[]) _array;
          if (statistics == null)
          {
-            for (int i = 0; i < Count; i++)
+            for (int i = Offset; i < Offset+Count; i++)
             {
                yield return typed[i];
             }
@@ -65,14 +68,14 @@ namespace Parquet.Data
 
          T min = default;
          T max = default;
-         for (int i = 0; i < Count; i++)
+         for (int i = Offset; i < Offset+Count; i++)
          {
             T current = typed[i];
             yield return current;
 
             hashSet.Add(current);
 
-            if (i == 0)
+            if (i == Offset)
             {
                min = current;
                max = current;

--- a/src/Parquet/Data/BasicDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicDataTypeHandler.cs
@@ -118,21 +118,21 @@ namespace Parquet.Data
 
       public abstract Array GetArray(int minCount, bool rent, bool isNullable);
 
-      public abstract ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount);
+      public abstract ArrayView PackDefinitions(Array data, int offset, int count, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount);
 
       public abstract Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags);
 
-      protected ArrayView PackDefinitions<TNullable>(TNullable[] data, int maxDefinitionLevel, out int[] definitionLevels, out int definitionsLength, out int nullCount)
+      protected ArrayView PackDefinitions<TNullable>(TNullable[] data, int offset, int count, int maxDefinitionLevel, out int[] definitionLevels, out int definitionsLength, out int nullCount)
          where TNullable : class
       {
-         definitionLevels = IntPool.Rent(data.Length);
-         definitionsLength = data.Length;
+         definitionLevels = IntPool.Rent(count);
+         definitionsLength = count;
 
          nullCount = 0;
-         WritableArrayView<TNullable> result = ArrayView.CreateWritable<TNullable>(data.Length);
+         WritableArrayView<TNullable> result = ArrayView.CreateWritable<TNullable>(count);
          int ir = 0;
 
-         for (int i = 0; i < data.Length; i++)
+         for (int i = offset; i < count; i++)
          {
             TNullable value = data[i];
 

--- a/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
@@ -36,9 +36,9 @@ namespace Parquet.Data
          return new TSystemType[minCount];
       }
 
-      public override ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
+      public override ArrayView PackDefinitions(Array data, int offset, int count, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
       {
-         return PackDefinitions((TSystemType?[])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
+         return PackDefinitions((TSystemType?[])data, offset, count, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }
 
       public override Array UnpackDefinitions(Array untypedSource, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)
@@ -72,27 +72,28 @@ namespace Parquet.Data
 
       }
 
-      private ArrayView PackDefinitions(TSystemType?[] data, int maxDefinitionLevel, out int[] definitionLevels, out int definitionsLength, out int nullCount)
+      private ArrayView PackDefinitions(TSystemType?[] data, int offset, int count, int maxDefinitionLevel, out int[] definitionLevels, out int definitionsLength, out int nullCount)
       {
-         definitionLevels = IntPool.Rent(data.Length);
-         definitionsLength = data.Length;
+         definitionLevels = IntPool.Rent(count);
+         definitionsLength = count;
 
-         WritableArrayView<TSystemType> result = ArrayView.CreateWritable<TSystemType>(data.Length);
+         WritableArrayView<TSystemType> result = ArrayView.CreateWritable<TSystemType>(count);
          int ir = 0;
          nullCount = 0;
-         
-         for(int i = 0; i < data.Length; i++)
+
+         int y = 0;
+         for (int i = offset; i < (offset + count); i++, y++)
          {
             TSystemType? value = data[i];
 
             if(value == null)
             {
-               definitionLevels[i] = 0;
+               definitionLevels[y] = 0;
                nullCount++;
             }
             else
             {
-               definitionLevels[i] = maxDefinitionLevel;
+               definitionLevels[y] = maxDefinitionLevel;
                result[ir++] = value.Value;
             }
          }

--- a/src/Parquet/Data/Concrete/ByteArrayDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/ByteArrayDataTypeHandler.cs
@@ -73,9 +73,9 @@ namespace Parquet.Data.Concrete
          return reader.ReadBytes(length);
       }
 
-      public override ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
+      public override ArrayView PackDefinitions(Array data, int offset, int count, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
       {
-         return PackDefinitions((byte[][])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
+         return PackDefinitions((byte[][])data, offset, count, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }
 
       public override Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)

--- a/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
@@ -94,9 +94,9 @@ namespace Parquet.Data.Concrete
          return ReadSingle(reader, tse, length, true);
       }
 
-      public override ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
+      public override ArrayView PackDefinitions(Array data, int offset, int count, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
       {
-         return PackDefinitions((string[])data, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
+         return PackDefinitions((string[])data, offset, count, maxDefinitionLevel, out definitions, out definitionsLength, out nullCount);
       }
 
       public override Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags)

--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -12,6 +12,9 @@ namespace Parquet.Data
    {
       private readonly IDataTypeHandler _dataTypeHandler;
 
+      private readonly int _offset;
+      private readonly int _count = -1;
+
       private DataColumn(DataField field)
       {
          Field = field ?? throw new ArgumentNullException(nameof(field));
@@ -25,9 +28,23 @@ namespace Parquet.Data
       /// <param name="field"></param>
       /// <param name="data"></param>
       /// <param name="repetitionLevels"></param>
-      public DataColumn(DataField field, Array data, int[] repetitionLevels = null) : this(field)
+      public DataColumn(DataField field, Array data, int[] repetitionLevels = null) : this(field, data, 0, -1, repetitionLevels)
+      {
+      }
+
+      /// <summary>
+      /// 
+      /// </summary>
+      /// <param name="field"></param>
+      /// <param name="data"></param>
+      /// <param name="offset"></param>
+      /// <param name="count"></param>
+      /// <param name="repetitionLevels"></param>
+      public DataColumn(DataField field, Array data, int offset, int count, int[] repetitionLevels = null) : this(field)
       {
          Data = data ?? throw new ArgumentNullException(nameof(data));
+         _offset = offset;
+         _count = count;
 
          RepetitionLevels = repetitionLevels;
       }
@@ -59,6 +76,16 @@ namespace Parquet.Data
       public Array Data { get; private set; }
 
       /// <summary>
+      /// Offset of the array
+      /// </summary>
+      public int Offset => _offset;
+
+      /// <summary>
+      /// Length of the array
+      /// </summary>
+      public int Count => _count > -1 ? _count : Data.Length;
+
+      /// <summary>
       /// Repetition levels if any.
       /// </summary>
       public int[] RepetitionLevels { get; private set; }
@@ -83,8 +110,8 @@ namespace Parquet.Data
 
       internal ArrayView PackDefinitions(int maxDefinitionLevel, out int[] pooledDefinitionLevels, out int definitionLevelCount, out int nullCount)
       {
-         pooledDefinitionLevels = ArrayPool<int>.Shared.Rent(Data.Length);
-         definitionLevelCount = Data.Length;
+         pooledDefinitionLevels = ArrayPool<int>.Shared.Rent(Count);
+         definitionLevelCount = Count;
 
          bool isNullable = Field.ClrType.IsNullable() || Data.GetType().GetElementType().IsNullable();
 
@@ -92,15 +119,15 @@ namespace Parquet.Data
          {
             SetPooledDefinitionLevels(maxDefinitionLevel, pooledDefinitionLevels);
             nullCount = 0; //definitely no nulls here
-            return new ArrayView(Data);
+            return new ArrayView(Data, Offset, Count);
          }
 
-         return _dataTypeHandler.PackDefinitions(Data, maxDefinitionLevel, out pooledDefinitionLevels, out definitionLevelCount, out nullCount);
+         return _dataTypeHandler.PackDefinitions(Data, Offset, Count, maxDefinitionLevel, out pooledDefinitionLevels, out definitionLevelCount, out nullCount);
       }
 
       void SetPooledDefinitionLevels(int maxDefinitionLevel, int[] pooledDefinitionLevels)
       {
-         for (int i = 0; i < Data.Length; i++)
+         for (int i = 0; i < Count; i++)
          {
             pooledDefinitionLevels[i] = maxDefinitionLevel;
          }
@@ -113,7 +140,7 @@ namespace Parquet.Data
             return RepetitionLevels.Count(rl => rl == 0);
          }
 
-         return Data.Length;
+         return Count;
       }
 
       /// <summary>

--- a/src/Parquet/Data/IDataTypeHandler.cs
+++ b/src/Parquet/Data/IDataTypeHandler.cs
@@ -48,7 +48,7 @@ namespace Parquet.Data
 
       Array MergeDictionary(Array dictionary, int[] indexes, Array data, int offset, int length);
 
-      ArrayView PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount);
+      ArrayView PackDefinitions(Array data, int offset, int count, int maxDefinitionLevel, out int[] definitions, out int definitionsLength, out int nullCount);
 
       Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel, out bool[] hasValueFlags);
 

--- a/src/Parquet/Data/NonDataDataTypeHandler.cs
+++ b/src/Parquet/Data/NonDataDataTypeHandler.cs
@@ -42,7 +42,7 @@ namespace Parquet.Data
          throw new NotSupportedException();
       }
 
-      public ArrayView PackDefinitions(Array data,  int maxDefiniionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
+      public ArrayView PackDefinitions(Array data, int offset, int count, int maxDefiniionLevel, out int[] definitions, out int definitionsLength, out int nullCount)
       {
          throw new NotImplementedException();
       }

--- a/src/Parquet/Data/WritableArrayView.cs
+++ b/src/Parquet/Data/WritableArrayView.cs
@@ -8,11 +8,11 @@ namespace Parquet.Data
       private readonly T[] _typedArray;
       int _count;
 
-      public WritableArrayView(int length) : this(ArrayPool.Rent(length))
+      public WritableArrayView(int length) : this(ArrayPool.Rent(length), 0, length)
       {
       }
 
-      WritableArrayView(T[] array) : base(array)
+      WritableArrayView(T[] array, int offset, int count) : base(array, offset, count)
       {
          _typedArray = array;
       }

--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -46,7 +46,7 @@ namespace Parquet.File
       public Thrift.ColumnChunk Write(List<string> path, DataColumn column, IDataTypeHandler dataTypeHandler)
       {
          Thrift.ColumnChunk chunk = _footer.CreateColumnChunk(_compressionMethod, _stream, _schemaElement.Type, path, 0);
-         Thrift.PageHeader ph = _footer.CreateDataPage(column.Data.Length);
+         Thrift.PageHeader ph = _footer.CreateDataPage(column.Count);
          _footer.GetLevels(chunk, out int maxRepetitionLevel, out int maxDefinitionLevel);
 
          List<PageTag> pages = WriteColumn(column, _schemaElement, dataTypeHandler, maxRepetitionLevel, maxDefinitionLevel);
@@ -82,7 +82,7 @@ namespace Parquet.File
 
          using (var ms = new MemoryStream())
          {
-            Thrift.PageHeader dataPageHeader = _footer.CreateDataPage(column.Data.Length);
+            Thrift.PageHeader dataPageHeader = _footer.CreateDataPage(column.Count);
 
             //chain streams together so we have real streaming instead of wasting undefraggable LOH memory
             using (GapStream pageStream = DataStreamFactory.CreateWriter(ms, _compressionMethod, _compressionLevel, true))
@@ -94,7 +94,7 @@ namespace Parquet.File
                      WriteLevels(writer, column.RepetitionLevels, column.RepetitionLevels.Length, maxRepetitionLevel);
                   }
 
-                  ArrayView data = new ArrayView(column.Data);
+                  ArrayView data = new ArrayView(column.Data, column.Offset, column.Count);
 
                   if (maxDefinitionLevel > 0)
                   {

--- a/src/Parquet/ParquetRowGroupWriter.cs
+++ b/src/Parquet/ParquetRowGroupWriter.cs
@@ -62,7 +62,7 @@ namespace Parquet
 
          if (RowCount == null)
          {
-            if (column.Data.Length > 0 || column.Field.MaxRepetitionLevel == 0)
+            if (column.Count > 0 || column.Field.MaxRepetitionLevel == 0)
                RowCount = column.CalculateRowCount();
          }
 


### PR DESCRIPTION
The `WriteColumn` method on `ParquetRowGroupWriter` now accepts offset and count.

### Fixes

Issue #108

### Description

When writing large columns it was somewhat inefficient to have to allocate exactly correctly sized arrays. This new overload allows one to use shared arrays, for instance those from `ArrayPool<T>`, which may be larger than the length requested and thus require reading only a subset of the array.

I've made the changes and verified no breakages, and I've added two new (simple) tests for the new cases. But there may be subtleties that I'm not aware of and thus haven't covered by tests.

- [x] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->