### PR TITLE
Implement decimal validation according to spec

### DIFF
--- a/src/Parquet.Test/DecimalTypeTest.cs
+++ b/src/Parquet.Test/DecimalTypeTest.cs
@@ -1,4 +1,6 @@
-﻿using Parquet.Data.Rows;
+﻿using System;
+using Parquet.Data.Rows;
+using Parquet.Data;
 using Xunit;
 
 namespace Parquet.Test
@@ -12,6 +14,42 @@ namespace Parquet.Test
          Table table = ReadTestFileAsTable("test-types-with-decimal.parquet");
 
          Assert.Equal(1234.56m, table[0].Get<decimal>(decimalColumnIndex));
+      }
+
+      [Fact]
+      public void Validate_Scale_Zero_Should_Be_Allowed()
+      {
+         const int precision = 1;
+         const int scale = 0;
+         var field = new DecimalDataField("field-name", precision, scale);
+         Assert.Equal(field.Scale, scale);
+      }
+      
+      [Fact]
+      public void Validate_Negative_Scale_Should_Throws_Exception()
+      {
+         const int precision = 1;
+         const int scale = -1;
+         var ex =  Assert.Throws<ArgumentException>(() => new DecimalDataField("field-name", precision, scale));
+         Assert.Equal(ex.Message, "scale must be zero or a positive integer (Parameter 'scale')");
+      }
+      
+      [Fact]
+      public void Validate_Precision_Zero_Should_Throws_Exception()
+      {
+         const int precision = 0;
+         const int scale = 1;
+         var ex =  Assert.Throws<ArgumentException>(() => new DecimalDataField("field-name", precision, scale));
+         Assert.Equal(ex.Message, "precision is required and must be a non-zero positive integer (Parameter 'precision')");
+      }
+      
+      [Fact]
+      public void Validate_Scale_Bigger_Then_Precision_Throws_Exception()
+      {
+         const int precision = 3;
+         const int scale = 4;
+         var ex =  Assert.Throws<ArgumentException>(() => new DecimalDataField("field-name", precision, scale));
+         Assert.Equal(ex.Message, "scale must be less than the precision (Parameter 'scale')");
       }
    }
 }

--- a/src/Parquet/Data/Schema/DecimalDataField.cs
+++ b/src/Parquet/Data/Schema/DecimalDataField.cs
@@ -26,16 +26,18 @@ namespace Parquet.Data
       /// Constructs class instance
       /// </summary>
       /// <param name="name">The name of the column</param>
-      /// <param name="precision">Cusom precision</param>
+      /// <param name="precision">Custom precision</param>
       /// <param name="scale">Custom scale</param>
       /// <param name="forceByteArrayEncoding">Whether to force decimal type encoding as fixed bytes. Hive and Impala only understands decimals when forced to true.</param>
       /// <param name="hasNulls">Is 'decimal?'</param>
       /// <param name="isArray">Indicates whether this field is repeatable.</param>
-      public DecimalDataField(string name, int precision, int scale, bool forceByteArrayEncoding = false, bool hasNulls = true, bool isArray = false)
+      public DecimalDataField(string name, int precision, int scale = 0, bool forceByteArrayEncoding = false, bool hasNulls = true, bool isArray = false)
          : base(name, DataType.Decimal, hasNulls, isArray)
       {
-         if (precision < 1) throw new ArgumentException("precision cannot be less than 1", nameof(precision));
-         if (scale < 1) throw new ArgumentException("scale cannot be less than 1", nameof(scale));
+         // see https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal for more details.
+         if (precision < 1) throw new ArgumentException("precision is required and must be a non-zero positive integer", nameof(precision));
+         if (scale < 0) throw new ArgumentException("scale must be zero or a positive integer", nameof(scale));
+         if (scale >= precision) throw new ArgumentException("scale must be less than the precision", nameof(scale));
 
          Precision = precision;
          Scale = scale;


### PR DESCRIPTION
### Fixes
We noticed that the decimal field scale field is not according to spec, please let me know what you think of the solution.

Issue #
decimal field not following spec

### Description
https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal for more details.

- [ x] I have included unit tests validating this fix.
- [ docs pointing to class with updates] I have updated markdown documentation where required.
- [x ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->