### PR TITLE
161 Reuse buffer for string encoding from ArrayPool<byte>

### DIFF
--- a/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
@@ -116,12 +116,21 @@ namespace Parquet.Data.Concrete
          else
          {
             //transofrm to byte array first, as we need the length of the byte buffer, not string length
-            byte[] data = E.GetBytes(value);
-            if (includeLengthPrefix)
+            byte[] data = _bytePool.Rent(E.GetByteCount(value));
+            try
             {
-               writer.Write(data.Length);
+               int bytesWritten = E.GetBytes(value, 0, value.Length, data, 0);
+               if (includeLengthPrefix)
+               {
+                  writer.Write(bytesWritten);
+               }
+
+               writer.Write(data, 0, bytesWritten);
             }
-            writer.Write(data);
+            finally
+            {
+               _bytePool.Return(data);
+            }
          }
       }
 


### PR DESCRIPTION
### Fixes

Issue #161 

### Description

Use buffer from **ArrayPool\<byte\>** for string encoding to reduce RAM allocation

- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->