### PR TITLE
FIX: Check if Year is 0, set it to 1 then

### DIFF
--- a/src/Parquet/File/Values/Primitives/NanoTime.cs
+++ b/src/Parquet/File/Values/Primitives/NanoTime.cs
@@ -49,7 +49,9 @@ namespace Parquet.File.Values.Primitives
          L = (long)(J / 11);
          int Month = (int)(J + 2 - 12 * L);
          int Year = (int)(100 * (N - 49) + I + L);
-
+         // DateTimeOffset.MinValue.Year is 1
+         Year = Math.Max(Year, 1);
+         
          long timeOfDayTicks = nanoTime._timeOfDayNanos / 100;
 
          var result = new DateTimeOffset(Year, Month, Day,


### PR DESCRIPTION
NanoTime 1721424 equals to 0000-12-30 (YYYY-MM-DD) but DateTimeOffset.MinValue is 0001-01-01 => change Year to 1 (any better solution ?)

