### PR TITLE
Fix ArgumentNullException during serialisation when schema data field…

### DIFF
--- a/src/Parquet/Data/Schema/DataField.cs
+++ b/src/Parquet/Data/Schema/DataField.cs
@@ -43,7 +43,8 @@ namespace Parquet.Data
          : this(name,
               Discover(clrType).dataType,
               Discover(clrType).hasNulls,
-              Discover(clrType).isArray)
+              Discover(clrType).isArray,
+              null)
       {
          //todo: calls to Discover() can be killed by making a constructor method
       }
@@ -61,7 +62,7 @@ namespace Parquet.Data
          DataType = dataType;
          HasNulls = hasNulls;
          IsArray = isArray;
-         ClrPropName = propertyName;
+         ClrPropName = propertyName ?? name;
 
          MaxRepetitionLevel = isArray ? 1 : 0;
 

--- a/src/Parquet/Data/Schema/DateTimeDataField.cs
+++ b/src/Parquet/Data/Schema/DateTimeDataField.cs
@@ -18,9 +18,10 @@ namespace Parquet.Data
       /// <param name="name">The name.</param>
       /// <param name="format">The format.</param>
       /// <param name="hasNulls">Is 'DateTime?'</param>
-      /// <param name="isArray"></param>
-      public DateTimeDataField(string name, DateTimeFormat format, bool hasNulls = true, bool isArray = false)
-         : base(name, DataType.DateTimeOffset, hasNulls, isArray)
+      /// <param name="isArray">When true, each value of this field can have multiple values, similar to array in C#.</param>
+      /// <param name="propertyName">When set, uses this property to get the field's data.  When not set, uses the property that matches the name parameter.</param>
+      public DateTimeDataField(string name, DateTimeFormat format, bool hasNulls = true, bool isArray = false, string propertyName = null)
+         : base(name, DataType.DateTimeOffset, hasNulls, isArray, propertyName)
       {
          DateTimeFormat = format;
       }

--- a/src/Parquet/Data/Schema/DecimalDataField.cs
+++ b/src/Parquet/Data/Schema/DecimalDataField.cs
@@ -31,8 +31,9 @@ namespace Parquet.Data
       /// <param name="forceByteArrayEncoding">Whether to force decimal type encoding as fixed bytes. Hive and Impala only understands decimals when forced to true.</param>
       /// <param name="hasNulls">Is 'decimal?'</param>
       /// <param name="isArray">Indicates whether this field is repeatable.</param>
-      public DecimalDataField(string name, int precision, int scale = 0, bool forceByteArrayEncoding = false, bool hasNulls = true, bool isArray = false)
-         : base(name, DataType.Decimal, hasNulls, isArray)
+      /// <param name="propertyName">When set, uses this property to get the field's data.  When not set, uses the property that matches the name parameter.</param>
+      public DecimalDataField(string name, int precision, int scale = 0, bool forceByteArrayEncoding = false, bool hasNulls = true, bool isArray = false, string propertyName = null)
+         : base(name, DataType.Decimal, hasNulls, isArray, propertyName)
       {
          // see https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal for more details.
          if (precision < 1) throw new ArgumentException("precision is required and must be a non-zero positive integer", nameof(precision));


### PR DESCRIPTION
… is constructed with null propertyName

### Fixes

Issue #179 

### Description

If a schema is manually constructed using DataFields where propertyName == null then ParquetConvert.SerializeAsync(...) would throw an ArgumentNullException. This PR fixes that bug and also adds propertyName to the DateTimeDataField and DecimalDataField constructor arguments.

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->