### PR TITLE
Preserve ticks precision

### DIFF
--- a/src/Parquet.Test/File/Values/Primitives/NanoTimeTest.cs
+++ b/src/Parquet.Test/File/Values/Primitives/NanoTimeTest.cs
@@ -1,20 +1,30 @@
 ﻿using System;
+using System.Collections.Generic;
 using Parquet.File.Values.Primitives;
 using Xunit;
 
-namespace Parquet.Test.File.Values.Primitives
-{
-   public class NanoTimeTest
-   {
-      [Fact]
-      public void ConvertToDateTimeOffset_PreservesTicks()
-      {
-         var dto = new DateTimeOffset(2021, 05, 14, 17, 52, 31, TimeSpan.Zero);
-         dto = dto.Add(TimeSpan.FromTicks(1234567));
-         var nanoTime = new NanoTime(dto);
-         var convertedDto = (DateTimeOffset) nanoTime;
+namespace Parquet.Test.File.Values.Primitives {
+    public class NanoTimeTest {
+        [Theory]
+        [InlineData(637566187511234567)] // 2021-05-14T17:52:31.1234567+00:00 - Works before fix
+        [InlineData(637807514459104071)] // 2022-02-18T02:24:05.9104071+00:00 - Does not work before fix
+        [MemberData(nameof(GenerateRandomDateTime), 1000)] // Generate a bunch of random date times
+        public void ConvertToDateTimeOffset_PreservesTicks(long ticks) {
+            DateTimeOffset dto = new DateTime(ticks).ToUniversalTime();
+            var nanoTime = new NanoTime(dto);
+            var convertedDto = (DateTimeOffset)nanoTime;
 
-         Assert.Equal(dto, convertedDto);
-      }
-   }
+            Assert.Equal(dto, convertedDto);
+        }
+
+        public static IEnumerable<object[]> GenerateRandomDateTime(int num) {
+            var rand = new Random();
+            for(int i = 0; i < num; i++) {
+                var dateTime = new DateTimeOffset(2022, rand.Next(1, 13), rand.Next(1, 28), rand.Next(0, 24),
+                    rand.Next(0, 60), rand.Next(0, 60), rand.Next(0, 1000), TimeSpan.Zero);
+                dateTime = dateTime.AddTicks(rand.Next(0, (int)TimeSpan.TicksPerMillisecond));
+                yield return new object[] { dateTime.Ticks };
+            }
+        }
+    }
 }

--- a/src/Parquet/File/Values/Primitives/NanoTime.cs
+++ b/src/Parquet/File/Values/Primitives/NanoTime.cs
@@ -28,7 +28,7 @@ namespace Parquet.File.Values.Primitives
          }
 
          _julianDay = d + (153 * m - 457) / 5 + 365 * y + (y / 4) - (y / 100) + (y / 400) + 1721119;
-         _timeOfDayNanos = (long)(dt.TimeOfDay.TotalMilliseconds  * 1000000D);
+         _timeOfDayNanos = dt.TimeOfDay.Ticks * 100;
       }
 
       public void Write(BinaryWriter writer)


### PR DESCRIPTION
### Fixes

Issue #111 

### Description

Fix precision issue with conversion double -> long

- [x] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->