### PR TITLE
Fixed #188 - Reading full page from stream

### DIFF
--- a/src/Parquet.Test/DumbStreamTest.cs
+++ b/src/Parquet.Test/DumbStreamTest.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Parquet.Data;
+using Xunit;
+
+namespace Parquet.Test {
+    public class DumbStreamTest {
+        [Fact]
+        public async Task Read_from_stream_that_only_retuns_one_byte_at_the_time() {
+            DataField field = new("date", typeof(DateTimeOffset));
+            Schema schema = new(field);
+
+            using MemoryStream memoryFileStream = new();
+            using(ParquetWriter parquetWriter = await ParquetWriter.CreateAsync(schema, memoryFileStream)) {
+                using ParquetRowGroupWriter rowGroupWriter = parquetWriter.CreateRowGroup();
+                DateTimeOffset[] data = new DateTimeOffset[10000];
+                for(int i = 0; i < 10000; i++)
+                    data[i] = DateTimeOffset.UtcNow.AddMilliseconds(i);
+                await rowGroupWriter.WriteColumnAsync(new DataColumn(field, data, 0, 10000));
+            }
+
+            int fileSize = (int)memoryFileStream.Length;
+            using MemoryStream memoryStreamCopy = new(memoryFileStream.GetBuffer(), 0, fileSize);
+            using DumbStream bufferedStream = new(memoryStreamCopy);
+            using ParquetReader parquetReader = await ParquetReader.CreateAsync(bufferedStream);
+            for(int iterations = 0; iterations < 100; iterations++) {
+                using ParquetRowGroupReader rowGroupReader = parquetReader.OpenRowGroupReader(0);
+                await rowGroupReader.ReadColumnAsync(field);
+            }
+        }
+
+        private class DumbStream : Stream {
+            private readonly MemoryStream _memoryStream;
+            public DumbStream(MemoryStream memoryStream) { _memoryStream = memoryStream; }
+            public override bool CanRead => true;
+            public override bool CanSeek => true;
+            public override bool CanWrite => false;
+            public override long Length => _memoryStream.Length;
+            public override long Position { get => _memoryStream.Position; set => _memoryStream.Position = value; }
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) => _memoryStream.Read(buffer, offset, 1);
+            public override long Seek(long offset, SeekOrigin origin) => _memoryStream.Seek(offset, origin);
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => Task.FromResult(Read(buffer, offset, count));
+        }
+
+    }
+}


### PR DESCRIPTION
### Fixes

Issue #188

### Description

- Fixed bug in ReadPageData where it did not read all the page bytes from the stream

- [x] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->