### PR TITLE
Make ParquetWriter work with write-only streams

### DIFF
--- a/src/Parquet.Test/Parquet.Test.csproj
+++ b/src/Parquet.Test/Parquet.Test.csproj
@@ -24,6 +24,7 @@
          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
          <PrivateAssets>all</PrivateAssets>
       </PackageReference>
+       <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
    </ItemGroup>
 
    <ItemGroup>

--- a/src/Parquet/3rdparty/MeteredWriteStream.cs
+++ b/src/Parquet/3rdparty/MeteredWriteStream.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Parquet._3rdparty {
+    internal class MeteredWriteStream : Stream {
+        private readonly Stream _baseStream;
+
+        private long _written;
+
+        public MeteredWriteStream(Stream inner) {
+            _baseStream = inner;
+        }
+
+        public long TotalBytesWritten => _written;
+
+        public override void Flush() => _baseStream.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => _baseStream.FlushAsync(cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+        public override void SetLength(long value) => throw new NotImplementedException();
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        public override int Read(System.Span<byte> buffer) => throw new NotImplementedException();
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public override ValueTask<int> ReadAsync(System.Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public override int ReadByte() => throw new NotImplementedException();
+
+        public override void Write(byte[] buffer, int offset, int count) {
+            _baseStream.Write(buffer, offset, count);
+            _written += count;
+        }
+
+        public override void Write(System.ReadOnlySpan<byte> buffer) {
+            _baseStream.Write(buffer);
+            _written += buffer.Length;
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
+            await _baseStream.WriteAsync(buffer, offset, count, cancellationToken);
+            _written += count;
+        }
+
+        public override async ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {
+            await _baseStream.WriteAsync(buffer, cancellationToken);
+            _written += buffer.Length;
+        }
+
+        public override void WriteByte(byte value) {
+            ++_written;
+            _baseStream.WriteByte(value);
+        }
+
+        public override void CopyTo(Stream destination, int bufferSize) => throw new NotImplementedException();
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public override void Close() => _baseStream.Close();
+
+        public override bool CanRead => _baseStream.CanRead;
+
+        public override bool CanWrite => _baseStream.CanWrite;
+
+        public override bool CanSeek => _baseStream.CanSeek;
+
+        public override long Length => _baseStream.Length;
+
+        public override bool CanTimeout => _baseStream.CanTimeout;
+
+        public override int ReadTimeout {
+            get => _baseStream.ReadTimeout;
+            set => _baseStream.ReadTimeout = value;
+        }
+
+        public override int WriteTimeout {
+            get => _baseStream.WriteTimeout;
+            set => _baseStream.WriteTimeout = value;
+        }
+
+        public override long Position {
+            get => _written;
+            set => _baseStream.Position = value;
+        }
+
+        protected override void Dispose(bool disposing) {
+            base.Dispose(disposing);
+            if(disposing) {
+                _baseStream.Dispose();
+            }
+        }
+
+        public override async ValueTask DisposeAsync() {
+            await base.DisposeAsync();
+            await _baseStream.DisposeAsync();
+        }
+    }
+}

--- a/src/Parquet/ParquetRowGroupWriter.cs
+++ b/src/Parquet/ParquetRowGroupWriter.cs
@@ -23,7 +23,6 @@ namespace Parquet {
         private readonly CompressionMethod _compressionMethod;
         private readonly ParquetOptions _formatOptions;
         private readonly Thrift.RowGroup _thriftRowGroup;
-        private readonly long _rgStartPos;
         private readonly Thrift.SchemaElement[] _thschema;
         private int _colIdx;
 
@@ -41,7 +40,6 @@ namespace Parquet {
             _formatOptions = formatOptions;
 
             _thriftRowGroup = _footer.AddRowGroup();
-            _rgStartPos = _stream.Position;
             _thriftRowGroup.Columns = new List<Thrift.ColumnChunk>();
             _thschema = _footer.GetWriteableSchema();
         }

--- a/src/Parquet/ParquetWriter.cs
+++ b/src/Parquet/ParquetWriter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Parquet._3rdparty;
 using Parquet.Data;
 using Parquet.File;
 
@@ -27,7 +28,7 @@ namespace Parquet {
         public CompressionMethod CompressionMethod { get; set; } = CompressionMethod.Snappy;
 
         private ParquetWriter(Schema schema, Stream output, ParquetOptions formatOptions = null, bool append = false)
-           : base(output) {
+           : base(output?.CanSeek == true ? output : new MeteredWriteStream(output)) {
             if(output == null)
                 throw new ArgumentNullException(nameof(output));
 


### PR DESCRIPTION
### Fixes

Issue #192

### Description

Fixes a regression from 3.x where write-only streams throw an exception.

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required. (N/A)
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->