### PR TITLE
Remove `new()` constraint for Serialize methods

### DIFF
--- a/src/Parquet/ParquetConvert.cs
+++ b/src/Parquet/ParquetConvert.cs
@@ -33,8 +33,7 @@ namespace Parquet {
             ParquetSchema? schema = null,
             CompressionMethod compressionMethod = CompressionMethod.Snappy,
             int rowGroupSize = 5000,
-            bool append = false)
-            where T : new() {
+            bool append = false) {
 
             if(objectInstances == null)
                 throw new ArgumentNullException(nameof(objectInstances));
@@ -89,8 +88,7 @@ namespace Parquet {
             ParquetSchema? schema = null,
             CompressionMethod compressionMethod = CompressionMethod.Snappy,
             int rowGroupSize = 5000,
-            bool append = false)
-            where T : new() {
+            bool append = false) {
             using(Stream destination = System.IO.File.Create(filePath)) {
                 return await SerializeAsync(objectInstances, destination, schema, compressionMethod, rowGroupSize,
                     append);


### PR DESCRIPTION
This `new()` constraint is not necessary for `Serialize` methods. With the constraint, one cannot serialize types that have the new `required` keyword added for properties in C# 11 ([refer to documentation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/required)).