### PR TITLE
Library-Wide Schema improvements

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -1,7 +1,7 @@
 name: 'Full Workflow'
 
 env:
-  VERSION: 4.8.1
+  VERSION: 4.9.0
   ASM_VERSION: 4.0.0
 
 on:

--- a/docs/serialisation.md
+++ b/docs/serialisation.md
@@ -53,6 +53,12 @@ Serialisation tries to fit into C# ecosystem like a ninja 🥷, including custom
 - [`JsonIgnore`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonignoreattribute?view=net-7.0) - ignores property when reading or writing.
 - [`JsonPropertyOrder`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonpropertyorderattribute?view=net-6.0) - allows to reorder columns when writing to file (by default they are written in class definition order). Only root properties and struct (classes) properties can be ordered (it won't make sense to do the others).
 
+Where built-in JSON attributes are not sufficient, extra attributes are added.
+
+### Dates
+
+By default, dates (`DateTime`) are serialized as `INT96` number
+
 ## Nested Types
 
 You can also serialize [more complex types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#nested-types) supported by the Parquet format. Sometimes you might want to store more complex data in your parquet files, like lists or maps. These are called *nested types* and they can be useful for organizing your information. However, they also come with a trade-off: they make your code slower and use more CPU resources. That's why you should only use them when you really need them and not just because they look cool. Simple columns are faster and easier to work with, so stick to them whenever you can.

--- a/docs/serialisation.md
+++ b/docs/serialisation.md
@@ -57,7 +57,27 @@ Where built-in JSON attributes are not sufficient, extra attributes are added.
 
 ### Dates
 
-By default, dates (`DateTime`) are serialized as `INT96` number
+By default, dates (`DateTime`) are serialized as `INT96` number, which include nanoseconds in the day. In general, `INT96` is obsolete in Parquet, however older systems such as Impala and Hive are still actively using it to represent dates.
+
+Therefore, when this library sees `INT96` type, it will automatically treat it as a date for both serialization and deserialization.
+
+If you need to rather use a normal non-legacy date type, just annotate a property with `[ParquetTimestamp]`:
+
+```csharp
+[ParquetTimestamp]
+public DateTime TimestampDate { get; set; }
+```
+
+### Decimals Numbers
+
+By default, `decimal` is serialized with precision (number of digits in a number) of `38` and scale (number of digits to the right of the decimal point in a number) of `18`. If you need to use different precision/scale pair, use `[ParquetDecimal]` attribute:
+
+```csharp
+[ParquetDecimal(40, 20)]
+public decimal With_40_20 { get; set; }
+```
+
+
 
 ## Nested Types
 

--- a/docs/serialisation.md
+++ b/docs/serialisation.md
@@ -68,6 +68,15 @@ If you need to rather use a normal non-legacy date type, just annotate a propert
 public DateTime TimestampDate { get; set; }
 ```
 
+### Times
+
+By default, time (`TimeSpan`) is serialised with millisecond precision. but you can increase it by adding `[ParquetMicroSecondsTime]` attribute:
+
+```csharp
+[ParquetMicroSecondsTime]
+public TimeSpan MicroTime { get; set; }
+```
+
 ### Decimals Numbers
 
 By default, `decimal` is serialized with precision (number of digits in a number) of `38` and scale (number of digits to the right of the decimal point in a number) of `18`. If you need to use different precision/scale pair, use `[ParquetDecimal]` attribute:

--- a/src/Parquet.PerfRunner/Program.cs
+++ b/src/Parquet.PerfRunner/Program.cs
@@ -1,6 +1,7 @@
 ﻿// for performance tests only
 
 using BenchmarkDotNet.Running;
+using Parquet;
 using Parquet.PerfRunner.Benchmarks;
 
 if(args.Length == 1) {
@@ -18,7 +19,7 @@ if(args.Length == 1) {
 } else {
     //new VsParquetSharp().Main();
     //await new DataTypes().NullableInts();
-    var c = new Classes();
-    c.SetUp();
-    c.Serialise();
+    //var c = new Classes();
+    //c.SetUp();
+    //c.Serialise();
 }

--- a/src/Parquet.Test/File/Values/Primitives/BigDecimalTest.cs
+++ b/src/Parquet.Test/File/Values/Primitives/BigDecimalTest.cs
@@ -1,19 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Parquet.File.Values.Primitives;
+﻿using Parquet.File.Values.Primitives;
 using Xunit;
 
-namespace Parquet.Test.File.Values.Primitives
-{
-   public class BigDecimalTest
-   {
-      [Fact]
-      public void Valid_but_massive_bigdecimal()
-      {
-         var bd = new BigDecimal(83086059037282.54m, 38, 16);
+namespace Parquet.Test.File.Values.Primitives {
+    public class BigDecimalTest {
+        [Fact]
+        public void Valid_but_massive_bigdecimal() {
+            var bd = new BigDecimal(83086059037282.54m, 38, 16);
 
-         //if exception is not thrown (overflow) we're OK
-      }
-   }
+            //if exception is not thrown (overflow) we're OK
+        }
+    }
 }

--- a/src/Parquet.Test/Schema/SchemaTest.cs
+++ b/src/Parquet.Test/Schema/SchemaTest.cs
@@ -312,32 +312,6 @@ namespace Parquet.Test.Schema {
             }
         }
 
-        [Theory]
-        [InlineData(typeof(bool), TT.BOOLEAN, null)]
-        [InlineData(typeof(byte), TT.INT32, CT.UINT_8)]
-        [InlineData(typeof(sbyte), TT.INT32, CT.INT_8)]
-        [InlineData(typeof(short), TT.INT32, CT.INT_16)]
-        [InlineData(typeof(ushort), TT.INT32, CT.UINT_16)]
-        [InlineData(typeof(int), TT.INT32, CT.INT_32)]
-        [InlineData(typeof(uint), TT.INT32, CT.UINT_32)]
-        [InlineData(typeof(long), TT.INT64, CT.INT_64)]
-        [InlineData(typeof(ulong), TT.INT64, CT.UINT_64)]
-        [InlineData(typeof(BigInteger), TT.INT96, null)]
-        [InlineData(typeof(float), TT.FLOAT, null)]
-        [InlineData(typeof(double), TT.DOUBLE, null)]
-        [InlineData(typeof(byte[]), TT.BYTE_ARRAY, null)]
-        [InlineData(typeof(string), TT.BYTE_ARRAY, CT.UTF8)]
-        // decimal
-        [InlineData(typeof(DateTime), TT.INT96, null)]
-        // TimeSpan
-        // Interval
-        public void SystemTypeToThriftMapping(Type t, TT expectedTT, CT? expectedCT) {
-            Assert.True(SchemaEncoder.FindTypeTuple(t, out TT foundTT, out CT? foundCT));
-
-            Assert.Equal(expectedTT, foundTT);
-            Assert.Equal(expectedCT, foundCT);
-        }
-
         [Fact]
         public void Decode_list_normal() {
             ParquetSchema schema = ThriftFooter.Parse(

--- a/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
+++ b/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
@@ -247,6 +247,11 @@ namespace Parquet.Test.Serialisation {
 
             [ParquetTimestamp]
             public DateTime TimestampDate { get; set; }
+
+            public TimeSpan DefaultTime { get; set; }
+
+            [ParquetMicroSecondsTime]
+            public TimeSpan MicroTime { get; set; }
         }
 
         [Fact]
@@ -264,6 +269,24 @@ namespace Parquet.Test.Serialisation {
             Assert.True(s.DataFields[1] is DateTimeDataField);
             Assert.Equal(DateTimeFormat.DateAndTime, ((DateTimeDataField)s.DataFields[1]).DateTimeFormat);
         }
+
+        [Fact]
+        public void Time_default() {
+            ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
+
+            Assert.True(s.DataFields[2] is TimeSpanDataField);
+            Assert.Equal(TimeSpanFormat.MilliSeconds, ((TimeSpanDataField)s.DataFields[2]).TimeSpanFormat);
+        }
+
+        [Fact]
+        public void Time_micros() {
+            ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
+
+            Assert.True(s.DataFields[3] is TimeSpanDataField);
+            Assert.Equal(TimeSpanFormat.MicroSeconds, ((TimeSpanDataField)s.DataFields[3]).TimeSpanFormat);
+        }
+
+
 
         class DecimalPoco {
             public decimal Default { get; set; }

--- a/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
+++ b/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
@@ -239,5 +239,17 @@ namespace Parquet.Test.Serialisation {
                 expectedSchema.Equals(actualSchema),
                 expectedSchema.GetNotEqualsMessage(actualSchema, "expected", "actual"));
         }
+
+        class DatesPoco {
+
+            public DateTime DateOnly { get; set; }
+        }
+
+        [Fact]
+        public void Date_only() {
+            ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
+
+            DataField dateOnly = s.DataFields[0];
+        }
     }
 }

--- a/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
+++ b/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Parquet.Schema;
 using Parquet.Serialization;
+using Parquet.Serialization.Attributes;
 using Xunit;
 
 namespace Parquet.Test.Serialisation {
@@ -242,14 +243,52 @@ namespace Parquet.Test.Serialisation {
 
         class DatesPoco {
 
-            public DateTime DateOnly { get; set; }
+            public DateTime ImpalaDate { get; set; }
+
+            [ParquetTimestamp]
+            public DateTime TimestampDate { get; set; }
         }
 
         [Fact]
-        public void Date_only() {
+        public void Date_default_impala() {
             ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
 
-            DataField dateOnly = s.DataFields[0];
+            Assert.True(s.DataFields[0] is DateTimeDataField);
+            Assert.Equal(DateTimeFormat.Impala, ((DateTimeDataField)s.DataFields[0]).DateTimeFormat);
         }
+
+        [Fact]
+        public void Date_timestamp() {
+            ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
+
+            Assert.True(s.DataFields[1] is DateTimeDataField);
+            Assert.Equal(DateTimeFormat.DateAndTime, ((DateTimeDataField)s.DataFields[1]).DateTimeFormat);
+        }
+
+        class DecimalPoco {
+            public decimal Default { get; set; }
+
+            [ParquetDecimal(40, 20)]
+            public decimal With_40_20 { get; set; }
+        }
+
+        [Fact]
+        public void Decimal_default() {
+            ParquetSchema s = typeof(DecimalPoco).GetParquetSchema(true);
+
+            Assert.True(s.DataFields[0] is DecimalDataField);
+            Assert.Equal(38, ((DecimalDataField)s.DataFields[0]).Precision);
+            Assert.Equal(18, ((DecimalDataField)s.DataFields[0]).Scale);
+        }
+
+        [Fact]
+        public void Decimal_override() {
+            ParquetSchema s = typeof(DecimalPoco).GetParquetSchema(true);
+
+            Assert.True(s.DataFields[1] is DecimalDataField);
+            Assert.Equal(40, ((DecimalDataField)s.DataFields[1]).Precision);
+            Assert.Equal(20, ((DecimalDataField)s.DataFields[1]).Scale);
+        }
+
     }
 }

--- a/src/Parquet.Test/TestBase.cs
+++ b/src/Parquet.Test/TestBase.cs
@@ -87,10 +87,16 @@ namespace Parquet.Test {
             //for sanity, use disconnected streams
             byte[] data;
 
+            var options = new ParquetOptions();
+#if !NETCOREAPP3_1
+            if(value is DateOnly)
+                options.UseDateOnlyTypeForDates = true;
+#endif
+
             using(var ms = new MemoryStream()) {
                 // write single value
 
-                using(ParquetWriter writer = await ParquetWriter.CreateAsync(new ParquetSchema(field), ms)) {
+                using(ParquetWriter writer = await ParquetWriter.CreateAsync(new ParquetSchema(field), ms, options)) {
                     writer.CompressionMethod = compressionMethod;
 
                     using ParquetRowGroupWriter rg = writer.CreateRowGroup();

--- a/src/Parquet.Test/Types/EndToEndTypeTest.cs
+++ b/src/Parquet.Test/Types/EndToEndTypeTest.cs
@@ -145,9 +145,9 @@ namespace Parquet.Test.Types {
             bool equal;
             if(input.expectedValue == null && actual == null)
                 equal = true;
-            else if(actual.GetType().IsArrayOf<byte>() && input.expectedValue != null)
+            else if(actual.GetType().IsArrayOf<byte>() && input.expectedValue != null) {
                 equal = ((byte[])actual).SequenceEqual((byte[])input.expectedValue);
-            else if(actual.GetType() == typeof(DateTime)) {
+            } else if(actual.GetType() == typeof(DateTime)) {
                 var dtActual = (DateTime)actual;
                 Assert.Equal(DateTimeKind.Utc, dtActual.Kind);
                 var dtExpected = (DateTime)input.expectedValue!;
@@ -155,8 +155,9 @@ namespace Parquet.Test.Types {
                     ? DateTime.SpecifyKind(dtExpected, DateTimeKind.Utc) // assumes value is UTC
                     : dtExpected.ToUniversalTime();
                 equal = dtActual.Equals(dtExpected);
-            } else
+            } else {
                 equal = actual.Equals(input.expectedValue);
+            }
 
             Assert.True(equal, $"{name}| expected: [{input.expectedValue}], actual: [{actual}], schema element: {input.field}");
         }

--- a/src/Parquet.Test/Types/EndToEndTypeTest.cs
+++ b/src/Parquet.Test/Types/EndToEndTypeTest.cs
@@ -143,9 +143,11 @@ namespace Parquet.Test.Types {
             object actual = await WriteReadSingle(input.field, input.expectedValue);
 
             bool equal;
-            if(input.expectedValue == null && actual == null)                 equal = true;
-else if(actual.GetType().IsArrayOf<byte>() && input.expectedValue != null)                 equal = ((byte[])actual).SequenceEqual((byte[])input.expectedValue);
-else if(actual.GetType() == typeof(DateTime)) {
+            if(input.expectedValue == null && actual == null)
+                equal = true;
+            else if(actual.GetType().IsArrayOf<byte>() && input.expectedValue != null)
+                equal = ((byte[])actual).SequenceEqual((byte[])input.expectedValue);
+            else if(actual.GetType() == typeof(DateTime)) {
                 var dtActual = (DateTime)actual;
                 Assert.Equal(DateTimeKind.Utc, dtActual.Kind);
                 var dtExpected = (DateTime)input.expectedValue!;
@@ -153,7 +155,8 @@ else if(actual.GetType() == typeof(DateTime)) {
                     ? DateTime.SpecifyKind(dtExpected, DateTimeKind.Utc) // assumes value is UTC
                     : dtExpected.ToUniversalTime();
                 equal = dtActual.Equals(dtExpected);
-            } else                 equal = actual.Equals(input.expectedValue);
+            } else
+                equal = actual.Equals(input.expectedValue);
 
             Assert.True(equal, $"{name}| expected: [{input.expectedValue}], actual: [{actual}], schema element: {input.field}");
         }

--- a/src/Parquet.Test/Types/EndToEndTypeTest.cs
+++ b/src/Parquet.Test/Types/EndToEndTypeTest.cs
@@ -48,6 +48,9 @@ namespace Parquet.Test.Types {
                ["dateDateAndTime local kind"] = (new DateTimeDataField("dateDateAndTime unknown kind", DateTimeFormat.DateAndTime), new DateTime(2020, 06, 10, 11, 12, 13, DateTimeKind.Local)),
                // don't want any excess info in the offset INT32 doesn't contain or care about this data 
                ["dateDate"] = (new DateTimeDataField("dateDate", DateTimeFormat.Date), DateTime.UtcNow.RoundToDay()),
+#if !NETCOREAPP3_1
+               ["dateOnly"] = (new DataField<DateOnly>("dateOnly"), DateOnly.FromDateTime(DateTime.UtcNow)),
+#endif
                ["interval"] = (new DataField<Interval>("interval"), new Interval(3, 2, 1)),
                // time test(loses precision slightly)
                ["time_micros"] = (new TimeSpanDataField("timeMicros", TimeSpanFormat.MicroSeconds), new TimeSpan(DateTime.UtcNow.TimeOfDay.Ticks / 10 * 10)),
@@ -108,6 +111,9 @@ namespace Parquet.Test.Types {
         [InlineData("impala date local kind")]
         [InlineData("dateDateAndTime local kind")]
         [InlineData("dateDate")]
+#if !NETCOREAPP3_1
+        [InlineData("dateOnly")]
+#endif
         [InlineData("interval")]
         [InlineData("time_micros")]
         [InlineData("time_millis")]

--- a/src/Parquet/Data/DecimalFormatDefaults.cs
+++ b/src/Parquet/Data/DecimalFormatDefaults.cs
@@ -10,6 +10,7 @@
         /// The Default Precision value used when not explicitly defined; this is the value used prior to parquet-dotnet v3.9.
         /// </summary>
         public const int DefaultPrecision = 38;
+
         /// <summary>
         /// The Default Scale value used when not explicitly defined; this is the value used prior to parquet-dotnet v3.9.
         /// </summary>

--- a/src/Parquet/Encodings/SchemaEncoder.cs
+++ b/src/Parquet/Encodings/SchemaEncoder.cs
@@ -23,6 +23,9 @@ namespace Parquet.Encodings {
             typeof(decimal),
             typeof(BigInteger),
             typeof(DateTime),
+#if NET6_0_OR_GREATER
+            typeof(DateOnly),
+#endif
             typeof(TimeSpan),
             typeof(Interval),
             typeof(byte[]),
@@ -181,7 +184,11 @@ namespace Parquet.Encodings {
                     Thrift.ConvertedType.UINT_16 => typeof(ushort),
                     Thrift.ConvertedType.INT_32 => typeof(int),
                     Thrift.ConvertedType.UINT_32 => typeof(uint),
+#if NET6_0_OR_GREATER
+                    Thrift.ConvertedType.DATE => options.UseDateOnlyTypeForDates ? typeof(DateOnly) : typeof(DateTime),
+#else
                     Thrift.ConvertedType.DATE => typeof(DateTime),
+#endif
                     Thrift.ConvertedType.DECIMAL => typeof(decimal),
                     Thrift.ConvertedType.TIME_MILLIS => typeof(TimeSpan),
                     Thrift.ConvertedType.TIMESTAMP_MILLIS => typeof(DateTime),
@@ -417,6 +424,12 @@ namespace Parquet.Encodings {
                 } else {
                     tse.Type = Thrift.Type.INT96;
                 }
+#if NET6_0_OR_GREATER
+            } else if(st == typeof(DateOnly)) {         // DateOnly
+                tse.Type = Thrift.Type.INT32;
+                tse.LogicalType.DATE = new Thrift.DateType();
+                tse.Converted_type = Thrift.ConvertedType.DATE;
+#endif
             } else if(st == typeof(TimeSpan)) {         // TimeSpan
                 if(field is TimeSpanDataField dfTime) {
                     switch(dfTime.TimeSpanFormat) {

--- a/src/Parquet/Encodings/SchemaEncoder.cs
+++ b/src/Parquet/Encodings/SchemaEncoder.cs
@@ -418,20 +418,34 @@ namespace Parquet.Encodings {
                     tse.Type = Thrift.Type.INT96;
                 }
             } else if(st == typeof(TimeSpan)) {         // TimeSpan
-                tse.Type = Thrift.Type.INT32;
                 if(field is TimeSpanDataField dfTime) {
                     switch(dfTime.TimeSpanFormat) {
-                        case TimeSpanFormat.MicroSeconds:
-                            tse.Type = Thrift.Type.INT64;
-                            tse.Converted_type = Thrift.ConvertedType.TIME_MICROS;
-                            break;
                         case TimeSpanFormat.MilliSeconds:
                             tse.Type = Thrift.Type.INT32;
+                            tse.LogicalType.TIME = new Thrift.TimeType {
+                                IsAdjustedToUTC = true,
+                                Unit = new Thrift.TimeUnit { MILLIS = new Thrift.MilliSeconds() }
+                            };
                             tse.Converted_type = Thrift.ConvertedType.TIME_MILLIS;
                             break;
-
-                            //other cases are just default
+                        case TimeSpanFormat.MicroSeconds:
+                            tse.Type = Thrift.Type.INT64;
+                            tse.LogicalType.TIME = new Thrift.TimeType {
+                                IsAdjustedToUTC = true,
+                                Unit = new Thrift.TimeUnit { MICROS = new Thrift.MicroSeconds() }
+                            };
+                            tse.Converted_type = Thrift.ConvertedType.TIME_MICROS;
+                            break;
+                        default:
+                            throw new NotImplementedException($"{dfTime.TimeSpanFormat} time format is not implemented");
                     }
+                } else {
+                    tse.Type = Thrift.Type.INT32;
+                    tse.LogicalType.TIME = new Thrift.TimeType {
+                        IsAdjustedToUTC = true,
+                        Unit = new Thrift.TimeUnit { MILLIS = new Thrift.MilliSeconds() }
+                    };
+                    tse.Converted_type = Thrift.ConvertedType.TIME_MILLIS;
                 }
             } else if(st == typeof(Interval)) {         // Interval
                 tse.Type = Thrift.Type.FIXED_LEN_BYTE_ARRAY;

--- a/src/Parquet/Extensions/OtherExtensions.cs
+++ b/src/Parquet/Extensions/OtherExtensions.cs
@@ -39,6 +39,13 @@ namespace Parquet {
             return (int)diff.TotalDays;
         }
 
+#if NET6_0_OR_GREATER
+        public static int ToUnixDays(this DateOnly dto) {
+            TimeSpan diff = new DateTime(dto.Year, dto.Month, dto.Day) - UnixEpoch;
+            return (int)diff.TotalDays;
+        }
+#endif
+
         public static DateTime ToUtc(this DateTime dto) =>
             dto.Kind == DateTimeKind.Unspecified
                 ? DateTime.SpecifyKind(dto, DateTimeKind.Utc)

--- a/src/Parquet/Extensions/SpanExtensions.cs
+++ b/src/Parquet/Extensions/SpanExtensions.cs
@@ -206,6 +206,19 @@ namespace System {
             }
         }
 
+#if NET6_0_OR_GREATER
+        public static void MinMax(this ReadOnlySpan<DateOnly> span, out DateOnly min, out DateOnly max) {
+            min = span.IsEmpty ? default(DateOnly) : span[0];
+            max = min;
+            foreach(DateOnly i in span) {
+                if(i < min)
+                    min = i;
+                if(i > max)
+                    max = i;
+            }
+        }
+#endif
+
         public static void MinMax(this ReadOnlySpan<TimeSpan> span, out TimeSpan min, out TimeSpan max) {
             min = span.IsEmpty ? default(TimeSpan) : span[0];
             max = min;

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -33,7 +33,7 @@ namespace Parquet.File {
 
             return new ThriftFooter(new Thrift.FileMetaData {
                 Schema = slst
-            }).CreateModelSchema(null);
+            }).CreateModelSchema(new ParquetOptions());
         }
 
         public ThriftFooter(ParquetSchema schema, long totalRowCount) {
@@ -160,7 +160,7 @@ namespace Parquet.File {
 
 #region [ Conversion to Model Schema ]
 
-        public ParquetSchema CreateModelSchema(ParquetOptions? formatOptions) {
+        public ParquetSchema CreateModelSchema(ParquetOptions formatOptions) {
             int si = 0;
             Thrift.SchemaElement tse = _fileMeta.Schema[si++];
             var container = new List<Field>();
@@ -170,7 +170,7 @@ namespace Parquet.File {
             return new ParquetSchema(container);
         }
 
-        private void CreateModelSchema(FieldPath? path, IList<Field> container, int childCount, ref int si, ParquetOptions? formatOptions) {
+        private void CreateModelSchema(FieldPath? path, IList<Field> container, int childCount, ref int si, ParquetOptions formatOptions) {
             for(int i = 0; i < childCount && si < _fileMeta.Schema.Count; i++) {
                 Field? se = SchemaEncoder.Decode(_fileMeta.Schema, formatOptions, ref si, out int ownedChildCount);
                 if(se == null)

--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -126,4 +126,8 @@
       </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Serialization\Attributes\" />
+    </ItemGroup>
+
 </Project>

--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -126,8 +126,4 @@
       </Compile>
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Serialization\Attributes\" />
-    </ItemGroup>
-
 </Project>

--- a/src/Parquet/ParquetOptions.cs
+++ b/src/Parquet/ParquetOptions.cs
@@ -16,6 +16,14 @@ namespace Parquet {
         /// </summary>
         public bool TreatBigIntegersAsDates { get; set; } = true;
 
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// When set to true, parquet dates will be deserialized as <see cref="DateOnly"/>, otherwise
+        /// as <see cref="DateTime"/> with missing time part.
+        /// </summary>
+        public bool UseDateOnlyTypeForDates { get; set; } = false;
+#endif
+
         /// <summary>
         /// Whether to use dictionary encoding for string columns. Other column types are not supported.
         /// </summary>

--- a/src/Parquet/Schema/TimeSpanDataField.cs
+++ b/src/Parquet/Schema/TimeSpanDataField.cs
@@ -16,9 +16,10 @@ namespace Parquet.Schema {
         /// <param name="name">The name.</param>
         /// <param name="format">The format.</param>
         /// <param name="isNullable"></param>
-        public TimeSpanDataField(string name, TimeSpanFormat format, bool isNullable = false)
-           : base(name, typeof(TimeSpan)) {
-            IsNullable = isNullable;
+        /// <param name="isArray"></param>
+        /// <param name="propertyName"></param>
+        public TimeSpanDataField(string name, TimeSpanFormat format, bool? isNullable = null, bool? isArray = null, string? propertyName = null)
+           : base(name, typeof(TimeSpan), isNullable, isArray, propertyName) {
             TimeSpanFormat = format;
         }
     }

--- a/src/Parquet/Serialization/Attributes/ParquetDecimalAttribute.cs
+++ b/src/Parquet/Serialization/Attributes/ParquetDecimalAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Parquet.Serialization.Attributes {
+
+    /// <summary>
+    /// Annotates a <see cref="decimal"/> property to allow customizing precision and scale
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class ParquetDecimalAttribute : Attribute {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="precision"></param>
+        /// <param name="scale"></param>
+        public ParquetDecimalAttribute(int precision, int scale) {
+            Precision = precision;
+            Scale = scale;
+        }
+
+        /// <summary>
+        /// Precision
+        /// </summary>
+        public int Precision { get; }
+
+        /// <summary>
+        /// Scale
+        /// </summary>
+        public int Scale { get; }
+    }
+}

--- a/src/Parquet/Serialization/Attributes/ParquetMicroSecondsTimeAttribute.cs
+++ b/src/Parquet/Serialization/Attributes/ParquetMicroSecondsTimeAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Parquet.Serialization.Attributes {
+
+    /// <summary>
+    /// Specifies that <see cref="TimeSpan"/> field should be serialised with microseconds precision (not default milliseconds).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class ParquetMicroSecondsTimeAttribute : Attribute {
+    }
+}

--- a/src/Parquet/Serialization/Attributes/ParquetTimestampAttribute.cs
+++ b/src/Parquet/Serialization/Attributes/ParquetTimestampAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Parquet.Serialization.Attributes {
+
+    /// <summary>
+    /// Specifies that a property of type <see cref="DateTime"/> should be serialized as Parquet timestamp, which is internally
+    /// an int64 number.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class ParquetTimestampAttribute : Attribute {
+    }
+}

--- a/src/Parquet/Serialization/ParquetSerializer.cs
+++ b/src/Parquet/Serialization/ParquetSerializer.cs
@@ -62,7 +62,9 @@ namespace Parquet.Serialization {
             }
 
             bool append = options != null && options.Append;
-            using(ParquetWriter writer = await ParquetWriter.CreateAsync(striper.Schema, destination, null, append, cancellationToken)) {
+            using(ParquetWriter writer = await ParquetWriter.CreateAsync(striper.Schema, destination,
+                options?.ParquetOptions,
+                append, cancellationToken)) {
 
                 if(options != null) {
                     writer.CompressionMethod = options.CompressionMethod;
@@ -105,10 +107,12 @@ namespace Parquet.Serialization {
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="source"></param>
+        /// <param name="options"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
         public static async Task<IList<T>> DeserializeAsync<T>(Stream source,
+            ParquetOptions? options = null,
             CancellationToken cancellationToken = default)
             where T : new() {
 
@@ -123,7 +127,7 @@ namespace Parquet.Serialization {
 
             var result = new List<T>();
 
-            using ParquetReader reader = await ParquetReader.CreateAsync(source);
+            using ParquetReader reader = await ParquetReader.CreateAsync(source, options, cancellationToken: cancellationToken);
             for(int rgi = 0; rgi < reader.RowGroupCount; rgi++) {
                 using ParquetRowGroupReader rg = reader.OpenRowGroupReader(rgi);
 

--- a/src/Parquet/Serialization/ParquetSerializerOptions.cs
+++ b/src/Parquet/Serialization/ParquetSerializerOptions.cs
@@ -32,5 +32,10 @@ namespace Parquet.Serialization {
         /// Custom row group size, if different from 
         /// </summary>
         public int? RowGroupSize { get; set; }
+
+        /// <summary>
+        /// Further customisations
+        /// </summary>
+        public ParquetOptions? ParquetOptions { get; set; } = new ParquetOptions();
     }
 }

--- a/src/Parquet/Serialization/TypeExtensions.cs
+++ b/src/Parquet/Serialization/TypeExtensions.cs
@@ -85,11 +85,12 @@ namespace Parquet.Serialization {
                 r = new DataField(name, t, propertyName: propertyName);
             }
 
+            // legacy attribute parsing
             ParquetColumnAttribute? columnAttr = pi?.GetCustomAttribute<ParquetColumnAttribute>();
-
             if(columnAttr != null) {
                 if(columnAttr.UseListField) {
-                    return new ListField(r.Name, t, propertyName, columnAttr.ListContainerName, columnAttr.ListElementName);
+                    Type nt = new DataField(name, t).ClrNullableIfHasNullsType;
+                    return new ListField(r.Name, nt, propertyName, columnAttr.ListContainerName, columnAttr.ListElementName);
                 }
 
                 if(t == typeof(TimeSpan))

--- a/src/Parquet/Serialization/TypeExtensions.cs
+++ b/src/Parquet/Serialization/TypeExtensions.cs
@@ -74,6 +74,12 @@ namespace Parquet.Serialization {
                 r = new DateTimeDataField(name,
                     isTimestamp ? DateTimeFormat.DateAndTime : DateTimeFormat.Impala,
                     propertyName: propertyName);
+            } else if(t == typeof(TimeSpan)) {
+                r = new TimeSpanDataField(name,
+                    pi?.GetCustomAttribute<ParquetMicroSecondsTimeAttribute>() == null
+                        ? TimeSpanFormat.MilliSeconds
+                        : TimeSpanFormat.MicroSeconds,
+                    propertyName: propertyName);
             } else if(t == typeof(decimal)) {
                 ParquetDecimalAttribute? ps = pi?.GetCustomAttribute<ParquetDecimalAttribute>();
                 r = ps == null
@@ -200,6 +206,7 @@ namespace Parquet.Serialization {
                     .Select(p => MakeField(p, forWriting, makeArrays))
                     .Where(f => f != null)
                     .Select(f => f!)
+                    .OrderBy(f => f.Order)
                     .ToArray();
 
                 if(fields.Length == 0)


### PR DESCRIPTION
- low-level: full logical types support in Parquet Thrift schema
- class serializer supports custom attributes to customize serialisation of dates, times, and decimals.
- added support for .NET 6 `DateOnly` type.