### PR TITLE
Add support to .NET 6 TimeOnly type

### DIFF
--- a/src/Parquet.Test/ParquetEncoderTest.cs
+++ b/src/Parquet.Test/ParquetEncoderTest.cs
@@ -19,6 +19,13 @@ namespace Parquet.Test {
 
             Assert.Equal(new TimeSpan(0, 0, 1), decoded[0]);
             Assert.Equal(new TimeSpan(0, 0, 30), decoded[1]);
+            
+#if NET6_0_OR_GREATER
+            var decodedAsTimeOnly = new TimeOnly[2];
+            ParquetPlainEncoder.Decode(source.ToArray().AsSpan(), decodedAsTimeOnly.AsSpan(), new SchemaElement { Type = Meta.Type.INT64 });
+            Assert.Equal(new TimeOnly(0, 0, 1), decodedAsTimeOnly[0]);
+            Assert.Equal(new TimeOnly(0, 0, 30), decodedAsTimeOnly[1]);
+#endif
         }
     }
 }

--- a/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
+++ b/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
@@ -252,6 +252,15 @@ namespace Parquet.Test.Serialisation {
 
             [ParquetMicroSecondsTime]
             public TimeSpan MicroTime { get; set; }
+            
+#if NET6_0_OR_GREATER
+            public DateOnly ImpalaDateOnly { get; set; }
+
+            public TimeOnly DefaultTimeOnly { get; set; }
+
+            [ParquetMicroSecondsTime]
+            public TimeOnly MicroTimeOnly { get; set; }
+#endif
         }
 
         [Fact]
@@ -286,7 +295,32 @@ namespace Parquet.Test.Serialisation {
             Assert.Equal(TimeSpanFormat.MicroSeconds, ((TimeSpanDataField)s.DataFields[3]).TimeSpanFormat);
         }
 
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void DateOnly_timestamp() {
+            ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
 
+            Assert.True(s.DataFields[4].GetType() == typeof(DataField));
+            Assert.Equal(SchemaType.Data, s.DataFields[4].SchemaType);
+            Assert.Equal(typeof(DateOnly), s.DataFields[4].ClrType);
+        }
+        
+        [Fact]
+        public void TimeOnly_default() {
+            ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
+
+            Assert.True(s.DataFields[5] is TimeOnlyDataField);
+            Assert.Equal(TimeSpanFormat.MilliSeconds, ((TimeOnlyDataField)s.DataFields[5]).TimeSpanFormat);
+        }
+
+        [Fact]
+        public void TimeOnly_micros() {
+            ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
+
+            Assert.True(s.DataFields[6] is TimeOnlyDataField);
+            Assert.Equal(TimeSpanFormat.MicroSeconds, ((TimeOnlyDataField)s.DataFields[6]).TimeSpanFormat);
+        }
+#endif
 
         class DecimalPoco {
             public decimal Default { get; set; }

--- a/src/Parquet.Test/Types/EndToEndTypeTest.cs
+++ b/src/Parquet.Test/Types/EndToEndTypeTest.cs
@@ -55,7 +55,11 @@ namespace Parquet.Test.Types {
                // time test(loses precision slightly)
                ["time_micros"] = (new TimeSpanDataField("timeMicros", TimeSpanFormat.MicroSeconds), new TimeSpan(DateTime.UtcNow.TimeOfDay.Ticks / 10 * 10)),
                ["time_millis"] = (new TimeSpanDataField("timeMillis", TimeSpanFormat.MilliSeconds), new TimeSpan(DateTime.UtcNow.TimeOfDay.Ticks / 10000 * 10000)),
-
+#if NET6_0_OR_GREATER
+               ["timeonly_micros"] = (new TimeOnlyDataField("timeMicros", TimeSpanFormat.MicroSeconds), new TimeOnly(DateTime.UtcNow.TimeOfDay.Ticks / 10 * 10)),
+               ["timeonly_millis"] = (new TimeOnlyDataField("timeMillis", TimeSpanFormat.MilliSeconds), new TimeOnly(DateTime.UtcNow.TimeOfDay.Ticks / 10000 * 10000)),
+#endif
+               
                ["byte min value"] = (new DataField<byte>("byte"), byte.MinValue),
                ["byte max value"] = (new DataField<byte>("byte"), byte.MaxValue),
                ["signed byte min value"] = (new DataField<sbyte>("sbyte"), sbyte.MinValue),
@@ -121,6 +125,10 @@ namespace Parquet.Test.Types {
         [InlineData("interval")]
         [InlineData("time_micros")]
         [InlineData("time_millis")]
+#if NET6_0_OR_GREATER
+        [InlineData("timeonly_micros")]
+        [InlineData("timeonly_millis")]
+#endif
 
         [InlineData("byte min value")]
         [InlineData("byte max value")]

--- a/src/Parquet/Extensions/SpanExtensions.cs
+++ b/src/Parquet/Extensions/SpanExtensions.cs
@@ -217,6 +217,17 @@ namespace System {
                     max = i;
             }
         }
+        
+        public static void MinMax(this ReadOnlySpan<TimeOnly> span, out TimeOnly min, out TimeOnly max) {
+            min = span.IsEmpty ? default(TimeOnly) : span[0];
+            max = min;
+            foreach(TimeOnly i in span) {
+                if(i < min)
+                    min = i;
+                if(i > max)
+                    max = i;
+            }
+        }
 #endif
 
         public static void MinMax(this ReadOnlySpan<TimeSpan> span, out TimeSpan min, out TimeSpan max) {

--- a/src/Parquet/Extensions/UntypedArrayExtensions.tt
+++ b/src/Parquet/Extensions/UntypedArrayExtensions.tt
@@ -11,7 +11,7 @@
 <# 
     var types = new[] { "bool?", "byte?", "sbyte?", "short?", "ushort?", "int?", "uint?", "long?", "ulong?", "BigInteger?", "float?", "double?", "decimal?", "DateTime?", "TimeSpan?", "Interval?", "string", "byte[]", "Guid?" }; 
 
-    var net6_types = new[] { "DateOnly?" };
+    var net6_types = new[] { "DateOnly?", "TimeOnly?" };
     string nn(string nt) => nt.EndsWith("?") ? nt.Substring(0, nt.Length - 1) : nt;
 #>
 namespace Parquet.Extensions {

--- a/src/Parquet/ParquetOptions.cs
+++ b/src/Parquet/ParquetOptions.cs
@@ -22,6 +22,18 @@ namespace Parquet {
         /// as <see cref="DateTime"/> with missing time part.
         /// </summary>
         public bool UseDateOnlyTypeForDates { get; set; } = false;
+
+        /// <summary>
+        /// When set to true, parquet times with millisecond precision will be deserialized as <see cref="TimeOnly"/>, otherwise
+        /// as <see cref="TimeSpan"/> with missing time part.
+        /// </summary>
+        public bool UseTimeOnlyTypeForTimeMillis { get; set; } = false;
+
+        /// <summary>
+        /// When set to true, parquet times with microsecond precision will be deserialized as <see cref="TimeOnly"/>, otherwise
+        /// as <see cref="TimeSpan"/> with missing time part.
+        /// </summary>
+        public bool UseTimeOnlyTypeForTimeMicros { get; set; } = false;
 #endif
 
         /// <summary>
@@ -35,5 +47,6 @@ namespace Parquet {
         /// Uniqueness factor needs to be less or equal than this threshold.
         /// </summary>
         public double DictionaryEncodingThreshold { get; set; } = 0.8;
+
     }
 }

--- a/src/Parquet/Schema/TimeOnlyDataField.cs
+++ b/src/Parquet/Schema/TimeOnlyDataField.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Parquet.Schema {
+    /// <summary>
+    /// Schema element for <see cref="TimeOnly"/> which allows to specify precision
+    /// </summary>
+    public class TimeOnlyDataField : DataField {
+        /// <summary>
+        /// Desired data format, Parquet specific
+        /// </summary>
+        public TimeSpanFormat TimeSpanFormat { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeOnlyDataField"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="format">The format.</param>
+        /// <param name="isNullable"></param>
+        /// <param name="isArray"></param>
+        /// <param name="propertyName"></param>
+        public TimeOnlyDataField(string name, TimeSpanFormat format, bool? isNullable = null, bool? isArray = null, string? propertyName = null)
+           : base(name, typeof(TimeOnly), isNullable, isArray, propertyName) {
+            TimeSpanFormat = format;
+        }
+    }
+}

--- a/src/Parquet/Schema/TimeOnlyDataField.cs
+++ b/src/Parquet/Schema/TimeOnlyDataField.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+#if NET6_0_OR_GREATER
 namespace Parquet.Schema {
     /// <summary>
     /// Schema element for <see cref="TimeOnly"/> which allows to specify precision
@@ -24,3 +25,4 @@ namespace Parquet.Schema {
         }
     }
 }
+#endif

--- a/src/Parquet/Serialization/TypeExtensions.cs
+++ b/src/Parquet/Serialization/TypeExtensions.cs
@@ -60,6 +60,14 @@ namespace Parquet.Serialization {
                         ? TimeSpanFormat.MilliSeconds
                         : TimeSpanFormat.MicroSeconds,
                     propertyName: propertyName);
+#if NET6_0_OR_GREATER
+            } else if(t == typeof(TimeOnly)) {
+                r = new TimeOnlyDataField(name,
+                    pi?.GetCustomAttribute<ParquetMicroSecondsTimeAttribute>() == null
+                        ? TimeSpanFormat.MilliSeconds
+                        : TimeSpanFormat.MicroSeconds,
+                    propertyName: propertyName);
+#endif
             } else if(t == typeof(decimal)) {
                 ParquetDecimalAttribute? ps = pi?.GetCustomAttribute<ParquetDecimalAttribute>();
                 r = ps == null


### PR DESCRIPTION
This pull request adds support to TimeOnly while trying to be as similar as possible to TimeSpan.

TimeOnly is more expressive when serializing data meant to be a time of the day rather than an interval of time. Too new fields are added to ParquetOptions to select TimeOnly instead of TimeSpan for deserializing: UseTimeOnlyTypeForTimeMillis (for time fields with millisecond precision) and UseTimeOnlyTypeForTimeMicros for selecting TimeOnly when one finds a time field with microsecond precision. This is similar to the filed UseDateOnlyTypeForDates for choosing DateOnly.

Best regards.

