### PR TITLE
Fix precision issues writing DateTime as milliseconds

### DIFF
--- a/src/Parquet.Test/Extensions/OtherExtensionsTest.cs
+++ b/src/Parquet.Test/Extensions/OtherExtensionsTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using Xunit;
+
+namespace Parquet.Test.Extensions {
+    public class OtherExtensionsTest {
+
+        [Theory]
+        [InlineData("1969-12-31T23:59:59.0001Z", -1000)]
+        [InlineData("1970-01-01T00:00:00.0001Z", 0)]
+        [InlineData("9999-12-31T23:59:59.999Z", 253402300799999)]
+        public void ToUnixMilliseconds_truncates_milliseconds_correctly(string dateString, long expectedMilliseconds) {
+            var dateTime = DateTime.Parse(dateString, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+
+            long actualMilliseconds = dateTime.ToUnixMilliseconds();
+
+            Assert.Equal(expectedMilliseconds, actualMilliseconds);
+        }
+    }
+}

--- a/src/Parquet/Extensions/OtherExtensions.cs
+++ b/src/Parquet/Extensions/OtherExtensions.cs
@@ -6,6 +6,7 @@ using Parquet.Schema;
 namespace Parquet {
     static class OtherExtensions {
         private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private const long UnixEpochMilliseconds = 62_135_596_800_000L;
 
         public static int GetBitWidth(this int value) {
             for(int i = 0; i < 64; i++) {
@@ -26,7 +27,8 @@ namespace Parquet {
         }
 
         public static long ToUnixMilliseconds(this DateTime dto) {
-            return new DateTimeOffset(dto).ToUnixTimeMilliseconds();
+            long milliseconds = dto.Ticks / TimeSpan.TicksPerMillisecond;
+            return milliseconds - UnixEpochMilliseconds;
         }
 
         public static DateTime AsUnixDaysInDateTime(this int unixDays) {

--- a/src/Parquet/Extensions/OtherExtensions.cs
+++ b/src/Parquet/Extensions/OtherExtensions.cs
@@ -26,8 +26,7 @@ namespace Parquet {
         }
 
         public static long ToUnixMilliseconds(this DateTime dto) {
-            TimeSpan diff = dto - UnixEpoch;
-            return (long)diff.TotalMilliseconds;
+            return new DateTimeOffset(dto).ToUnixTimeMilliseconds();
         }
 
         public static DateTime AsUnixDaysInDateTime(this int unixDays) {


### PR DESCRIPTION
Fixes #312 by switching to [DateTimeOffset.ToUnixTimeMilliseconds](https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tounixtimemilliseconds) instead of a custom implementation to keep things simple.

The first and third test cases fail without this change and all three pass with this change. I didn't know if there were any tests that actually write a parquet file and read it back that I should update. This PR just tests the method being modified.