### PR TITLE
Use PLAIN encoding for columns without defined data

### DIFF
--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -168,6 +168,8 @@ namespace Parquet.Data {
             return span;
         }
 
+        internal bool IsDeltaEncodable => DefinedData.Length > 0 && Field.IsDeltaEncodable;
+
         internal long CalculateRowCount() =>
             Field.MaxRepetitionLevel > 0
                 ? RepetitionLevels?.Count(rl => rl == 0) ?? 0

--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -128,7 +128,7 @@ namespace Parquet.File {
             // data page
             using(MemoryStream ms = _rmsMgr.GetStream()) {
                 // data page Num_values also does include NULLs
-                PageHeader ph = _footer.CreateDataPage(column.NumValues, pc.HasDictionary, column.Field.IsDeltaEncodable);
+                PageHeader ph = _footer.CreateDataPage(column.NumValues, pc.HasDictionary, column.IsDeltaEncodable);
                 if(pc.HasRepetitionLevels) {
                     WriteLevels(ms, pc.RepetitionLevels!, pc.RepetitionLevels!.Length, column.Field.MaxRepetitionLevel);
                 }
@@ -144,7 +144,7 @@ namespace Parquet.File {
                     RleBitpackedHybridEncoder.Encode(ms, indexes.AsSpan(0, indexesLength), bitWidth);
                 } else {
                     Array data = pc.GetPlainData(out int offset, out int count);
-                    if(column.Field.IsDeltaEncodable) {
+                    if(column.IsDeltaEncodable) {
                         DeltaBinaryPackedEncoder.Encode(data, offset, count, ms, column.Statistics);
                         chunk.MetaData!.Encodings[2] = Encoding.DELTA_BINARY_PACKED;
                     } else {


### PR DESCRIPTION
Part of #375. If a column only contains null values, the array passed to `DeltaBinaryPackedEncoder` will be empty and cause the encoder to return without writing a header. This breaks compatibility with some readers such as Apache parquet-mr that try to read the header.

I verified writing a parquet file containing such a column can be read by parquet-mr with this change but failed before.