### PR TITLE
Fix/encode json numbers with invariant culture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ obj/
 BenchmarkDotNet.Artifacts/
 *.swp
 Parquet.sln.DotSettings.user
+.DS_Store

--- a/src/Parquet/Extensions/StringBuilderExtensions.cs
+++ b/src/Parquet/Extensions/StringBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text;
 using Parquet.Rows;
 using Parquet.Schema;
@@ -120,6 +121,15 @@ namespace Parquet.Extensions {
                 sb.Append(quote);
                 sb.Append(Convert.ToBase64String((byte[])value));
                 sb.Append(quote);
+            } 
+            else if(t == typeof(decimal)) {
+                sb.Append(((decimal)value).ToString(CultureInfo.InvariantCulture));
+            }
+            else if(t == typeof(float)) {
+                sb.Append(((float)value).ToString(CultureInfo.InvariantCulture));
+            }
+            else if(t == typeof(double)) {
+                sb.Append(((double)value).ToString(CultureInfo.InvariantCulture));
             }
             else {
                 sb.Append(value.ToString());


### PR DESCRIPTION
Explicitly use invariant culture when encoding number types, eliminating the potential for generating invalid JSON.

Fixes https://github.com/aloneguid/parquet-dotnet/issues/133