### PR TITLE
Feature/add row group serialization

### DIFF
--- a/docs/release-history.md
+++ b/docs/release-history.md
@@ -5,7 +5,8 @@
 - Nullable `TimeSpan` support in `ParquetSerializer` by @cliedeman in #409.
 - `DataFrame` support for `int16/uint16` types by @asmirnov82 in #469.
 - Dropping build targets for .NET Core 3.1 and .NET 7.0 (STS). This should not affect anyone as .NET 6 and 8 are the LTS versions now.
- - Upgraded to latest IronCompress dependency.
+- Added convenience methods to serialize/deserialize collections into a single row group in #506 by @piiertho. 
+- Upgraded to latest IronCompress dependency.
 
 ### Bug fixes
 
@@ -13,7 +14,7 @@
 - decimal scale condition check fixed in #504 by @sierzput.
 
 ### Parquet Floor
-- telemetry agreement made more clear to understand.
+- telemetry agreement changed and made clearer to understand.
 
 ## 4.23.5
 

--- a/src/Parquet/Serialization/ParquetSerializer.cs
+++ b/src/Parquet/Serialization/ParquetSerializer.cs
@@ -65,6 +65,22 @@ namespace Parquet.Serialization {
         }
 
         /// <summary>
+        /// Serialize a collection into one row group using an existing writer.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="objectInstances"></param>
+        /// <param name="cancellationToken"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task SerializeRowGroupAsync<T>(ParquetWriter writer, IEnumerable<T> objectInstances,
+            CancellationToken cancellationToken) {
+            using ParquetRowGroupWriter rowGroupWritter = writer.CreateRowGroup();
+            object boxedStriper = _typeToStriper.GetOrAdd(typeof(T), _ => new Striper<T>(typeof(T).GetParquetSchema(false)));
+            var striper = (Striper<T>)boxedStriper;
+
+            await SerializeRowGroupAsync(writer, striper, objectInstances, cancellationToken);
+        }
+
+        /// <summary>
         /// Serialize 
         /// </summary>
         /// <typeparam name="T"></typeparam>


### PR DESCRIPTION
At my company we need to have more granularity regarding serialization and deserialization of row groups.  
We use pools of objects to avoid instantiations and we multi-thread modifications of objects in those pools and parquet row group writing using DoubleBuffer (which use the mentionned pools).  
This way we have fast and memory efficient parquet jobs.  

We were using version 3 of this nuget, using reflection to access private methods of `ClrBridge` class to get fast and memory efficient serialization.  
As serialization API implementation changed a lot, we cannot achieve the same on version 4.  
So here is our contribution.

This adds a method to serialize a collection into a single row group.
This adds methods to deserialize a single row group into an existing collection.
This adds methods to deserialize row group per row group using `IAsyncEnumerable`.