### PR TITLE
ParquetReader.RowGroups property

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,17 +29,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        dotnet: [3.1.x, 6.0.x, 7.0.x, 8.0.x]
-        exclude:
-        - os: macos-latest
-          dotnet: 3.1.x
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{ matrix.dotnet }}
+        dotnet-version: |
+          3.1.x
+          6.0.x
+          7.0.x
+          8.0.x
     - name: Setup Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,17 +29,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        dotnet: [3.1.x, 6.0.x, 7.0.x, 8.0.x]
+        exclude:
+        - os: macos-latest
+          dotnet: 3.1.x
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
-          7.0.x
-          8.0.x
+        dotnet-version: ${{ matrix.dotnet }}
     - name: Setup Python
       uses: actions/setup-python@v4
       with:

--- a/src/Parquet.Test/ParquetReaderTest.cs
+++ b/src/Parquet.Test/ParquetReaderTest.cs
@@ -270,6 +270,18 @@ namespace Parquet.Test {
             Assert.True(reader.CustomMetadata.ContainsKey("geo"));
             Assert.True(reader.CustomMetadata.ContainsKey("ARROW:schema"));
         }
+
+        [Theory]
+        [InlineData("multi.page.parquet")]
+        [InlineData("multi.page.v2.parquet")]
+        public async Task RowGroups_EnumeratesRowGroups(string parquetFile) {
+            using(ParquetReader reader = await ParquetReader.CreateAsync(OpenTestFile(parquetFile), leaveStreamOpen: false)) {
+
+                Assert.Single(reader.RowGroups);
+                IParquetRowGroupReader rowGroup = reader.RowGroups.Single();
+                Assert.Equal(927861, rowGroup.RowCount);
+            }
+        }
         
         class ReadableNonSeekableStream : DelegatedStream {
             public ReadableNonSeekableStream(Stream master) : base(master) {

--- a/src/Parquet/ParquetReader.cs
+++ b/src/Parquet/ParquetReader.cs
@@ -135,6 +135,11 @@ namespace Parquet {
         }
 
         /// <summary>
+        /// Collection of row group readers, fast random access and enumeration
+        /// </summary>
+        public IReadOnlyList<IParquetRowGroupReader> RowGroups => _groupReaders;
+
+        /// <summary>
         /// Reads entire row group's data columns in one go.
         /// </summary>
         /// <param name="rowGroupIndex">Index of the row group. Default to the first row group if not specified.</param>

--- a/src/Parquet/ParquetRowGroupReader.cs
+++ b/src/Parquet/ParquetRowGroupReader.cs
@@ -12,9 +12,54 @@ using Parquet.Schema;
 
 namespace Parquet {
     /// <summary>
+    /// Operations available on a row group reader, omitting Dispose, which is 
+    /// exposed on the implementing class for backward compatibility only.
+    /// </summary>
+    public interface IParquetRowGroupReader {
+        /// <summary>
+        /// Exposes raw metadata about this row group
+        /// </summary>
+        RowGroup RowGroup { get; }
+
+        /// <summary>
+        /// Gets the number of rows in this row group
+        /// </summary>
+        long RowCount { get; }
+
+        /// <summary>
+        /// Checks if this field exists in source schema
+        /// </summary>
+        bool ColumnExists(DataField field);
+
+        /// <summary>
+        /// Reads a column from this row group. Unlike writing, columns can be read in any order.
+        /// If the column is missing, an exception will be thrown.
+        /// </summary>
+        Task<DataColumn> ReadColumnAsync(DataField field, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets raw column chunk metadata for this field
+        /// </summary>
+        ColumnChunk? GetMetadata(DataField field);
+
+        /// <summary>
+        /// Get custom key-value metadata for a data field
+        /// </summary>
+        Dictionary<string, string> GetCustomMetadata(DataField field);
+
+        /// <summary>
+        /// Returns data column statistics for a particular data field
+        /// </summary>
+        /// <param name="field"></param>
+        /// <returns></returns>
+        /// <exception cref="ParquetException"></exception>
+        DataColumnStatistics? GetStatistics(DataField field);
+    }
+
+    /// <summary>
     /// Reader for Parquet row groups
     /// </summary>
-    public class ParquetRowGroupReader : IDisposable {
+    public class ParquetRowGroupReader : IDisposable, IParquetRowGroupReader {
         private readonly RowGroup _rowGroup;
         private readonly ThriftFooter _footer;
         private readonly Stream _stream;
@@ -118,12 +163,8 @@ namespace Parquet {
         }
 
         /// <summary>
-        /// 
+        /// Dispose isn't required, retained for backward compatibility
         /// </summary>
-        public void Dispose() {
-            //don't need to dispose anything here, but for clarity we implement IDisposable and client must use it as we may add something
-            //important in it later
-        }
-
+        public void Dispose() { }
     }
 }


### PR DESCRIPTION
Row group readers are created up-front and held in a list, so the `OpenRowGroupReader` method is just a wrapper around `list[n]`.

There is a note in the reader's `Dispose` method that says that although dispose is not required, it may be in the future so clients so clients have to take on extra ceremony. But the current design is super fast and efficient even with very large numbers of row groups, so it shouldn't be necessary.

By clarifying that `Dispose` isn't required, this enables a simple `ParquetReader.RowGroups` property that exposes a read-only list of row group readers. This then enables Linq chained expressions to operate on row groups, use `Reverse` to read from the end, `Where` to filter on column stats, and `ToAsyncEnumerable().SelectManyAwait` to deserialise into a stream of objects. Can do this with multiple sorted parquet sources and then merge them with [SortedMergeBy](https://viceroypenguin.github.io/SuperLinq/api/SuperLinq.Async.AsyncSuperEnumerable.SortedMergeBy.html), before batching them back into row groups and directing them to a destination stream. With the right extension methods a whole operation like this could be written declaratively.

Rather than causing a breaking change to existing clients I've added an interface that omits `Dispose` but retained it on the class, so the `RowGroups` property (which uses the non-disposable interface) makes it clear that disposal is unnecessary.