### PR TITLE
Support for Roslyn nullable annotations

### DIFF
--- a/src/Parquet.Test/DataAnalysis/DataFrameReaderTest.cs
+++ b/src/Parquet.Test/DataAnalysis/DataFrameReaderTest.cs
@@ -12,19 +12,19 @@ namespace Parquet.Test.DataAnalysis {
     public class DataFrameReaderTest : TestBase {
 
         [Theory]
-        [InlineData(typeof(short), (short)1, (short)2)]
-        [InlineData(typeof(short?), null, (short)2)]
-        [InlineData(typeof(int), 1, 2)]
-        [InlineData(typeof(int?), null, 2)]
-        [InlineData(typeof(bool), true, false)]
-        [InlineData(typeof(bool?), true, null)]
-        [InlineData(typeof(long), 1L, 2L)]
-        [InlineData(typeof(long?), 1L, 2L)]
-        [InlineData(typeof(ulong), 1UL, 2UL)]
-        [InlineData(typeof(ulong?), 1UL, 2UL)]
-        [InlineData(typeof(string), "1", "2")]
-        [InlineData(typeof(string), null, "2")]
-        public async Task Roundtrip_all_types(Type t, object? el1, object? el2) {
+        [InlineData(typeof(short), false, (short)1, (short)2)]
+        [InlineData(typeof(short?), false, null, (short)2)]
+        [InlineData(typeof(int), false, 1, 2)]
+        [InlineData(typeof(int?), false, null, 2)]
+        [InlineData(typeof(bool), false, true, false)]
+        [InlineData(typeof(bool?), false, true, null)]
+        [InlineData(typeof(long), false, 1L, 2L)]  
+        [InlineData(typeof(long?), false, 1L, 2L)]
+        [InlineData(typeof(ulong), false, 1UL, 2UL)]
+        [InlineData(typeof(ulong?), false, 1UL, 2UL)]
+        [InlineData(typeof(string), false, "1", "2")]
+        [InlineData(typeof(string), true, null, "2")]
+        public async Task Roundtrip_all_types(Type t, bool makeNullable, object? el1, object? el2) {
 
             // arrange
             using var ms = new MemoryStream();
@@ -34,7 +34,7 @@ namespace Parquet.Test.DataAnalysis {
 
 
             // make schema
-            var schema = new ParquetSchema(new DataField(t.Name, t));
+            var schema = new ParquetSchema(new DataField(t.Name, t, isNullable: makeNullable?true:null, isCompiledWithNullable: true));
 
             // make data
             using(ParquetWriter writer = await ParquetWriter.CreateAsync(schema, ms)) {

--- a/src/Parquet.Test/DictionaryEncodingTest.cs
+++ b/src/Parquet.Test/DictionaryEncodingTest.cs
@@ -33,7 +33,7 @@ namespace Parquet.Test {
             "zzz",
             };
 
-            var dataField = new DataField<string>("string");
+            var dataField = new DataField<string>("string", true);
             var parquetSchema = new ParquetSchema(dataField);
 
             using var stream = new MemoryStream();

--- a/src/Parquet.Test/Rows/RowsModelTest.cs
+++ b/src/Parquet.Test/Rows/RowsModelTest.cs
@@ -226,8 +226,8 @@ namespace Parquet.Test.Rows {
                new ParquetSchema(
                   new DataField<string>("isbn"),
                   new StructField("author",
-                     new DataField<string>("firstName"),
-                     new DataField<string>("lastName"))));
+                     new DataField<string>("firstName", true),
+                     new DataField<string>("lastName", true))));
             var ms = new MemoryStream();
 
             table.Add("12345-6", new Row("Hazel", "Nut"));

--- a/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
+++ b/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
@@ -538,6 +538,27 @@ namespace Parquet.Test.Serialisation {
             Assert.True(s.DataFields[2].IsNullable);
         }
 
+
+        class PocoClassNotNullable {
+            [JsonPropertyName("id")]
+            public long Id { get; set; }
+
+            [JsonPropertyName("value")]
+            public string Value { get; set; } = null!;
+
+            [JsonPropertyName("frequency")]
+            public double Frequency { get; set; }
+        }
+
+        [Fact]
+        public void Strings_NotNullable() {
+            ParquetSchema s = typeof(PocoClassNotNullable).GetParquetSchema(true);
+            Assert.False(s.DataFields[0].IsNullable);
+            Assert.False(s.DataFields[1].IsNullable);
+            Assert.False(s.DataFields[2].IsNullable);
+        }
+
+
         public interface IInterface {
             int Id { get; set; }
         }

--- a/src/Parquet/Encodings/ParquetPlainEncoder.cs
+++ b/src/Parquet/Encodings/ParquetPlainEncoder.cs
@@ -1072,8 +1072,10 @@ namespace Parquet.Encodings {
                     else
                         Array.Copy(BitConverter.GetBytes(len), 0, rb, rbOffset, sizeof(int));
                     rbOffset += sizeof(int);
-                    E.GetBytes(s, 0, s.Length, rb, rbOffset);
-                    rbOffset += len;
+                    if(len > 0) {
+                        E.GetBytes(s, 0, s.Length, rb, rbOffset);
+                        rbOffset += len;
+                    }
                 }
 
                 if(rbOffset > 0)

--- a/src/Parquet/Extensions/TypeExtensions.cs
+++ b/src/Parquet/Extensions/TypeExtensions.cs
@@ -135,6 +135,12 @@ namespace Parquet {
             return ti.GenericTypeArguments[0];
         }
 
+        public static bool CanNullifyType(this Type t) { 
+            TypeInfo ti = t.GetTypeInfo();
+
+            return !ti.IsClass;
+        }
+
         public static Type GetNullable(this Type t) {
             TypeInfo ti = t.GetTypeInfo();
 

--- a/src/Parquet/Extensions/TypeExtensions.cs
+++ b/src/Parquet/Extensions/TypeExtensions.cs
@@ -112,6 +112,13 @@ namespace Parquet {
                 (ti.IsGenericType && ti.GetGenericTypeDefinition() == typeof(Nullable<>));
         }
 
+        public static bool IsNullableStrict(this Type t) {
+            TypeInfo ti = t.GetTypeInfo();
+
+            return
+                (ti.IsGenericType && ti.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+
         public static bool IsSystemNullable(this Type t) {
             TypeInfo ti = t.GetTypeInfo();
 

--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -59,11 +59,11 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
 

--- a/src/Parquet/ParquetExtensions.cs
+++ b/src/Parquet/ParquetExtensions.cs
@@ -209,7 +209,7 @@ namespace Parquet {
         public static async Task WriteAsync(this DataFrame df, Stream outputStream, CancellationToken cancellationToken = default) {
             // create schema
             var schema = new ParquetSchema(
-                df.Columns.Select(col => new DataField(col.Name, col.DataType.GetNullable(), false)));
+                df.Columns.Select(col => new DataField(col.Name, col.DataType.GetNullable(), isNullable: col.DataType.CanNullifyType() ? null : col.NullCount > 0)));
 
             using ParquetWriter writer = await ParquetWriter.CreateAsync(schema, outputStream, cancellationToken: cancellationToken);
             using ParquetRowGroupWriter rgw = writer.CreateRowGroup();

--- a/src/Parquet/ParquetExtensions.cs
+++ b/src/Parquet/ParquetExtensions.cs
@@ -209,7 +209,7 @@ namespace Parquet {
         public static async Task WriteAsync(this DataFrame df, Stream outputStream, CancellationToken cancellationToken = default) {
             // create schema
             var schema = new ParquetSchema(
-                df.Columns.Select(col => new DataField(col.Name, col.DataType.GetNullable())));
+                df.Columns.Select(col => new DataField(col.Name, col.DataType.GetNullable(), false)));
 
             using ParquetWriter writer = await ParquetWriter.CreateAsync(schema, outputStream, cancellationToken: cancellationToken);
             using ParquetRowGroupWriter rgw = writer.CreateRowGroup();

--- a/src/Parquet/Schema/DataField.cs
+++ b/src/Parquet/Schema/DataField.cs
@@ -61,7 +61,7 @@ namespace Parquet.Schema {
         public DataField(string name, Type clrType, bool? isNullable = null, bool? isArray = null, string? propertyName = null, bool? isCompiledWithNullable = null)
            : base(name, SchemaType.Data) {
 
-            Discover(clrType, isCompiledWithNullable ?? false, out Type baseType, out bool discIsArray, out bool discIsNullable);
+            Discover(clrType, isCompiledWithNullable ?? true, out Type baseType, out bool discIsArray, out bool discIsNullable);
             ClrType = baseType;
             if(!SchemaEncoder.IsSupported(ClrType)) {
                 if(baseType == typeof(DateTimeOffset)) {

--- a/src/Parquet/Schema/DataField.cs
+++ b/src/Parquet/Schema/DataField.cs
@@ -183,13 +183,7 @@ namespace Parquet.Schema {
                 isArray = true;
             }
 
-            if(isCompiledWithNullable) {
-                bool isActualNullableType = baseType.IsNullableStrict();
-                if(isActualNullableType) {
-                    baseType = baseType.GetNonNullable();
-                    isNullable = isActualNullableType;
-                }
-            } else if (baseType.IsNullable()) {
+            if (baseType.IsNullable()) {
                 baseType = baseType.GetNonNullable();
                 isNullable = true;
             }

--- a/src/Parquet/Utils/NullableChecker.cs
+++ b/src/Parquet/Utils/NullableChecker.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Parquet.Utils {
+    /// <summary>
+    /// This class is used to check if nullable is enabled for a given type - otherwise, it is types will be assumed as nullable
+    /// </summary>
+    public static class NullableChecker {
+        /// <summary>
+        /// Checks if a type was compiled using Nullable enabled
+        /// See https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md for details
+        /// </summary>
+        /// <param name="type">Type to check</param>
+        /// <returns></returns>
+        public static bool IsNullableEnabled(Type type) {
+            // Check if the NullableContextAttribute is present on the type
+            CustomAttributeData? nullableContextAttribute = type.CustomAttributes
+                .FirstOrDefault(attr => attr.AttributeType.Name == "NullableContextAttribute" || attr.AttributeType.Name == "NullableAttribute");
+
+            if(nullableContextAttribute != null) {
+                return true;
+            }
+
+            // Check if any properties have the NullableContextAttribute
+            foreach(PropertyInfo? property in type.GetProperties()) {
+                nullableContextAttribute = property.CustomAttributes
+                    .FirstOrDefault(attr => attr.AttributeType.Name == "NullableAttribute");
+
+                if(nullableContextAttribute != null) {
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This is a fix for bug #535. The current parquet.net doesn't leverage compiler nullable when checking if members are nullable. This affects all classes - so any `string` property was marked as nullable in the schema. This PR adds checks for [Roslyn's annotations](https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md) to ensure that a field is nullable.

- Added checks for roslin compiler attributes to properly identify nullable and not nullable classes
- Added supporting unit tests
