### PR TITLE
Fix return of Decode methods to returning the actual destination length.

### DIFF
--- a/src/Parquet/Encodings/ParquetPlainEncoder.cs
+++ b/src/Parquet/Encodings/ParquetPlainEncoder.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Buffers;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Parquet.Data;
 using Parquet.Extensions;
@@ -594,21 +593,9 @@ namespace Parquet.Encodings {
             Write(destination, bytes);
         }
 
-        public static int Decode(Span<byte> source, Span<int> data) {
-            Span<byte> dataBytes = MemoryMarshal.AsBytes(data);
-            source.CopyWithLimitTo(dataBytes);
-            return data.Length;
-        }
-
         public static void Encode(ReadOnlySpan<uint> data, Stream destination) {
             ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(data);
             Write(destination, bytes);
-        }
-
-        public static int Decode(Span<byte> source, Span<uint> data) {
-            Span<byte> bytes = MemoryMarshal.AsBytes(data);
-            source.CopyWithLimitTo(bytes);
-            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<long> data, Stream destination) {
@@ -616,21 +603,9 @@ namespace Parquet.Encodings {
             Write(destination, bytes);
         }
 
-        public static int Decode(Span<byte> source, Span<long> data) {
-            Span<byte> bytes = MemoryMarshal.AsBytes(data);
-            source.CopyWithLimitTo(bytes);
-            return data.Length;
-        }
-
         public static void Encode(ReadOnlySpan<ulong> data, Stream destination) {
             ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(data);
             Write(destination, bytes);
-        }
-
-        public static int Decode(Span<byte> source, Span<ulong> data) {
-            Span<byte> bytes = MemoryMarshal.AsBytes(data);
-            source.CopyWithLimitTo(bytes);
-            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<BigInteger> data, Stream destination) {
@@ -638,10 +613,10 @@ namespace Parquet.Encodings {
             Write(destination, bytes);
         }
 
-        public static int Decode(Span<byte> source, Span<BigInteger> data) {
+        public static int Decode<T>(Span<byte> source, Span<T> data) where T : struct {
             Span<byte> bytes = MemoryMarshal.AsBytes(data);
             source.CopyWithLimitTo(bytes);
-            return data.Length;
+            return Math.Min(data.Length, source.Length / Unsafe.SizeOf<T>());
         }
 
         public static void Encode(ReadOnlySpan<decimal> data, Stream destination, SchemaElement tse) {
@@ -751,12 +726,6 @@ namespace Parquet.Encodings {
         public static void Encode(ReadOnlySpan<double> data, Stream destination) {
             ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(data);
             Write(destination, bytes);
-        }
-
-        public static int Decode(Span<byte> source, Span<double> data) {
-            Span<byte> bytes = MemoryMarshal.AsBytes(data);
-            source.CopyWithLimitTo(bytes);
-            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<float> data, Stream destination) {

--- a/src/Parquet/Encodings/ParquetPlainEncoder.cs
+++ b/src/Parquet/Encodings/ParquetPlainEncoder.cs
@@ -608,7 +608,7 @@ namespace Parquet.Encodings {
         public static int Decode(Span<byte> source, Span<uint> data) {
             Span<byte> bytes = MemoryMarshal.AsBytes(data);
             source.CopyWithLimitTo(bytes);
-            return source.Length / sizeof(uint);
+            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<long> data, Stream destination) {
@@ -619,7 +619,7 @@ namespace Parquet.Encodings {
         public static int Decode(Span<byte> source, Span<long> data) {
             Span<byte> bytes = MemoryMarshal.AsBytes(data);
             source.CopyWithLimitTo(bytes);
-            return source.Length / sizeof(long);
+            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<ulong> data, Stream destination) {
@@ -630,7 +630,7 @@ namespace Parquet.Encodings {
         public static int Decode(Span<byte> source, Span<ulong> data) {
             Span<byte> bytes = MemoryMarshal.AsBytes(data);
             source.CopyWithLimitTo(bytes);
-            return source.Length / sizeof(ulong);
+            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<BigInteger> data, Stream destination) {
@@ -641,7 +641,7 @@ namespace Parquet.Encodings {
         public static int Decode(Span<byte> source, Span<BigInteger> data) {
             Span<byte> bytes = MemoryMarshal.AsBytes(data);
             source.CopyWithLimitTo(bytes);
-            return source.Length / 12;
+            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<decimal> data, Stream destination, SchemaElement tse) {
@@ -756,7 +756,7 @@ namespace Parquet.Encodings {
         public static int Decode(Span<byte> source, Span<double> data) {
             Span<byte> bytes = MemoryMarshal.AsBytes(data);
             source.CopyWithLimitTo(bytes);
-            return source.Length / sizeof(double);
+            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<float> data, Stream destination) {
@@ -767,7 +767,7 @@ namespace Parquet.Encodings {
         public static int Decode(Span<byte> source, Span<float> data) {
             Span<byte> bytes = MemoryMarshal.AsBytes(data);
             source.CopyWithLimitTo(bytes);
-            return source.Length / sizeof(float);
+            return data.Length;
         }
 
         public static void Encode(ReadOnlySpan<byte[]> data, Stream destination) {


### PR DESCRIPTION
Solves #542 

Caused by `Decode` was returning the length of the source divided by the sizeof(T) instead of the length of the actually decoded data.

