### PR TITLE
fix: Make isAdjustedToUTC defualt to true and allow it to be set

### DIFF
--- a/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
+++ b/src/Parquet.Test/Serialisation/SchemaReflectorTest.cs
@@ -323,8 +323,11 @@ namespace Parquet.Test.Serialisation {
             [ParquetTimestamp]
             public DateTime TimestampDate { get; set; }
 
+            [ParquetTimestamp(useLogicalTimestamp: true, isAdjustedToUTC: false)]
+            public DateTime LogicalLocalTimestampDate { get; set; }
+            
             [ParquetTimestamp(useLogicalTimestamp: true)]
-            public DateTime LogicalTimestampDate { get; set; }
+            public DateTime LogicalUtcTimestampDate { get; set; }
 
             [ParquetTimestamp]
             public DateTime? NullableTimestampDate { get; set; }
@@ -387,11 +390,22 @@ namespace Parquet.Test.Serialisation {
         }
 
         [Fact]
-        public void Type_DateTime_LogicalTimestamp() {
+        public void Type_DateTime_LogicalLocalTimestamp() {
             ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
 
-            DataField df = s.FindDataField(nameof(DatesPoco.LogicalTimestampDate));
+            DataField df = s.FindDataField(nameof(DatesPoco.LogicalLocalTimestampDate));
             Assert.True(df is DateTimeDataField);
+            Assert.False(((DateTimeDataField)df).IsAdjustedToUTC);
+            Assert.Equal(DateTimeFormat.Timestamp, ((DateTimeDataField)df).DateTimeFormat);
+        }
+        
+        [Fact]
+        public void Type_DateTime_LogicalUtcTimestamp() {
+            ParquetSchema s = typeof(DatesPoco).GetParquetSchema(true);
+
+            DataField df = s.FindDataField(nameof(DatesPoco.LogicalUtcTimestampDate));
+            Assert.True(df is DateTimeDataField);
+            Assert.True(((DateTimeDataField)df).IsAdjustedToUTC);
             Assert.Equal(DateTimeFormat.Timestamp, ((DateTimeDataField)df).DateTimeFormat);
         }
 

--- a/src/Parquet/Serialization/Attributes/ParquetTimestampAttribute.cs
+++ b/src/Parquet/Serialization/Attributes/ParquetTimestampAttribute.cs
@@ -35,9 +35,11 @@ namespace Parquet.Serialization.Attributes {
         /// </summary>
         /// <param name="resolution"></param>
         /// <param name="useLogicalTimestamp"></param>
-        public ParquetTimestampAttribute(ParquetTimestampResolution resolution = ParquetTimestampResolution.Milliseconds, bool useLogicalTimestamp = false) {
+        /// <param name="isAdjustedToUTC"></param>
+        public ParquetTimestampAttribute(ParquetTimestampResolution resolution = ParquetTimestampResolution.Milliseconds, bool useLogicalTimestamp = false, bool isAdjustedToUTC = true) {
             Resolution = resolution;
             UseLogicalTimestamp = useLogicalTimestamp;
+            IsAdjustedToUTC = isAdjustedToUTC;
         }
 
         /// <summary>


### PR DESCRIPTION
Missed `IsAdjustedToUTC` in `ParquetTimestampAttribute`.
Default it to true because a local timestamp should be the exception.

Haven't thought through exactly how this would behave backwards compat. Will try to find time to setup a test where we convert from a non logical timestamp to a logical one to check the behaviour