### PR TITLE
[#436] Expose `RecyclableMemoryStreamManager` memory settings

### DIFF
--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -38,6 +38,8 @@ namespace Parquet.File {
             _compressionLevel = compressionLevel;
             _keyValueMetadata = keyValueMetadata;
             _options = options;
+            _rmsMgr.Settings.MaximumSmallPoolFreeBytes = options.MaximumSmallPoolFreeBytes;
+            _rmsMgr.Settings.MaximumLargePoolFreeBytes = options.MaximumLargePoolFreeBytes;
         }
 
         public async Task<ColumnChunk> WriteAsync(

--- a/src/Parquet/ParquetOptions.cs
+++ b/src/Parquet/ParquetOptions.cs
@@ -57,5 +57,39 @@ namespace Parquet {
         /// your readers do not understand it.
         /// </summary>
         public bool UseDeltaBinaryPackedEncoding { get; set; } = true;
+
+        /// <summary>
+        /// This option is passed to the <see cref="Microsoft.IO.RecyclableMemoryStreamManager"/> , 
+        /// which keeps a pool of streams in memory for reuse. 
+        /// By default when this option is unset, the RecyclableStreamManager 
+        /// will keep an unbounded amount of memory, which is 
+        /// "indistinguishable from a memory leak" per their documentation.
+        /// 
+        /// This does not restrict the size of the pool, but just allows 
+        /// the garbage collector to free unused memory over this limit.
+        /// 
+        /// You may want to adjust this smaller to reduce max memory usage, 
+        /// or larger to reduce garbage collection frequency.
+        /// 
+        /// Defaults to 16MB.  
+        /// </summary>
+        public int MaximumSmallPoolFreeBytes { get; set; } = 16 * 1024 * 1024;
+
+        /// <summary>
+        /// This option is passed to the <see cref="Microsoft.IO.RecyclableMemoryStreamManager"/> , 
+        /// which keeps a pool of streams in memory for reuse. 
+        /// By default when this option is unset, the RecyclableStreamManager 
+        /// will keep an unbounded amount of memory, which is 
+        /// "indistinguishable from a memory leak" per their documentation.
+        /// 
+        /// This does not restrict the size of the pool, but just allows 
+        /// the garbage collector to free unused memory over this limit.
+        /// 
+        /// You may want to adjust this smaller to reduce max memory usage, 
+        /// or larger to reduce garbage collection frequency.
+        /// 
+        /// Defaults to 64MB.
+        /// </summary>
+        public int MaximumLargePoolFreeBytes { get; set; } = 64 * 1024 * 1024;
     }
 }


### PR DESCRIPTION
Adds two fields to `ParquetOptions`: `MaximumSmallPoolFreeBytes` and `MaximumLargePoolFreeBytes`, which correspond to and update the settings of the same name in the `DataColumnWriter`'s `RecyclableMemoryStreamManager _rmsMgr` instance.

Will leave a handful of open questions as conversations on the code.

closes #436 