### PR TITLE
Fix #630 Calculate empty and null DL for nullable items

### DIFF
--- a/src/Parquet.Test/Serialisation/AdditionalDremelStriperTests.cs
+++ b/src/Parquet.Test/Serialisation/AdditionalDremelStriperTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Parquet.Serialization;
+using Parquet.Serialization.Dremel;
+using Parquet.Test.Serialisation.Paper;
+using Xunit;
+
+namespace Parquet.Test.Serialisation {
+    public class TestRow {
+        public List<int>? Numbers { get; set; } = [];
+        public List<string?>? Words { get; set; } = [];   
+    }
+
+    /// <summary>
+    /// Additional tests beyond the example given in the google paper, but needed for completeness.
+    /// </summary>
+    public class AdditionalDremelStriperTests {
+        private readonly Striper<TestRow> _striper;
+
+        public AdditionalDremelStriperTests() {
+            _striper = new Striper<TestRow>(typeof(TestRow).GetParquetSchema(false));
+        }
+
+        public static List<TestRow> NullEmptyListTestCases = [
+            new TestRow { Numbers = [123], Words = ["abc"] },
+            new TestRow { Numbers = [], Words = [] },
+            new TestRow { Numbers = [], Words = [null] },
+            new TestRow { Numbers = null, Words = null },
+        ];
+
+        [Fact]
+        public void Empty_Null_Lists_Nullable_Item() {
+            FieldStriper<TestRow> striper = _striper.FieldStripers[1];
+            ShreddedColumn col = striper.Stripe(striper.Field, NullEmptyListTestCases);
+            Assert.Equal(new string[] {"abc"}, col.Data);
+            Assert.Equal(new int[] { 0, 0, 0, 0 }, col.RepetitionLevels!);
+            Assert.Equal(new int[] { 3, 1, 2, 0}, col.DefinitionLevels!);
+        }
+
+        [Fact]
+        public void Empty_Null_Lists_NonNullable_Item() {
+            FieldStriper<TestRow> striper = _striper.FieldStripers[0];
+            ShreddedColumn col = striper.Stripe(striper.Field, NullEmptyListTestCases);
+            Assert.Equal(new int[] {123}, col.Data);
+            Assert.Equal(new int[] { 0, 0, 0, 0 }, col.RepetitionLevels!);
+            Assert.Equal(new int[] { 2, 1, 1, 0}, col.DefinitionLevels!);
+        }
+    }
+}

--- a/src/Parquet/Serialization/Dremel/FieldStriperCompiler.cs
+++ b/src/Parquet/Serialization/Dremel/FieldStriperCompiler.cs
@@ -200,6 +200,15 @@ namespace Parquet.Serialization.Dremel {
             return f.MaxDefinitionLevel;
         }
 
+        private static int GetNullCollectionDL(Field f)
+        {
+            return f.MaxDefinitionLevel - 2;    
+        }
+        
+        private static int GetEmptyCollectionDL(Field f) {
+            return f.MaxDefinitionLevel - 1;
+        }
+
         private static Type GetIdealUntypedType(Field f) {
             switch(f.SchemaType) {
                 case SchemaType.Data:
@@ -320,13 +329,13 @@ namespace Parquet.Serialization.Dremel {
                     Expression.Assign(countVar, Expression.Constant(0)),
                     Expression.IfThenElse(
                         Expression.Equal(levelProperty, Expression.Constant(null)),
-                        WriteMissingValue(dl - 2, currentRlVar),
+                        WriteMissingValue(GetNullCollectionDL(field), currentRlVar),
                         Expression.Block(
                             body,
                             // check if no elements are written and write out empty list if so
                             Expression.IfThen(
                                 Expression.Equal(countVar, Expression.Constant(0)),
-                                WriteMissingValue(dl - 1, currentRlVar))
+                                WriteMissingValue(GetEmptyCollectionDL(field), currentRlVar))
                             )));
             } else {
                 Expression element = levelProperty;


### PR DESCRIPTION
Fixes #630 .

Note, I think this case also doesn't work properly for deserialization, but I didn't look into that much (not needed for my use case).