### PR TITLE
Update README.md - add FastBCP in the "Used By" section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,8 @@ Whether you want to build apps for Linux, MacOS, Windows, iOS, Android, Tizen, X
 - [Kusto-loco - C# KQL query engine with flexible I/O layers and visualization](https://github.com/NeilMacMullen/kusto-loco).
 - [DeltaIO - Delta Lake implementation in pure .NET](https://github.com/aloneguid/delta).
 - [Personal Data Warehouse - Import(Excel/Parquet/SQL/Fabric)-Transform(C#/Python)-Report(SSRS)](https://github.com/BlazorData-Net/PersonalDataWarehouse).
+- [FastBCP - Export to parquet files in parallel from Oracle, SQL Server, MySQL, PostgreSQL, ODBC, Teradata, Netezza, SAP HANA, ClickHouse in one command line (Windows & Linux)](https://www.arpe.io/fastbcp/).
+
 
 *...raise a PR to appear here...*
 


### PR DESCRIPTION
Thanks to Parquet-dotnet FastBCP is ultra fast to generate parquet files from databases with parallelism and potentially partitionning 