### PR TITLE
Add support for additional integer types in encoder

### DIFF
--- a/src/Parquet.Test/Encodings/DeltaBinaryPackedEncodingTest.cs
+++ b/src/Parquet.Test/Encodings/DeltaBinaryPackedEncodingTest.cs
@@ -1,12 +1,48 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using Parquet.Encodings;
 using Xunit;
 
 namespace Parquet.Test.Encodings {
     public class DeltaBinaryPackedEncodingTest : TestBase {
+
+        #region Type Support Tests
+
+        [Theory]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(uint))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(ulong))]
+        public void IsSupported_AllIntegerTypes_ReturnsTrue(Type type) {
+            // Act
+            bool isSupported = DeltaBinaryPackedEncoder.IsSupported(type);
+
+            // Assert
+            Assert.True(isSupported, $"Type {type.Name} should be supported by delta encoding");
+        }
+
+        [Theory]
+        [InlineData(typeof(byte))]
+        [InlineData(typeof(sbyte))]
+        [InlineData(typeof(float))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(decimal))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(DateTime))]
+        [InlineData(typeof(bool))]
+        public void IsSupported_NonIntegerTypes_ReturnsFalse(Type type) {
+            // Act
+            bool isSupported = DeltaBinaryPackedEncoder.IsSupported(type);
+
+            // Assert
+            Assert.False(isSupported, $"Type {type.Name} should not be supported by delta encoding");
+        }
+
+        #endregion
 
         [Fact]
         public void EncodeAndDecodeInt32() {
@@ -184,5 +220,247 @@ namespace Parquet.Test.Encodings {
 
             Assert.Equal(input, des);
         }
+
+        #region Integer Compatible Types Tests
+
+
+        public static IEnumerable<object[]> NewIntegerTypeBasicTestData => new List<object[]> {
+            new object[] { new short[] { 7, 5, 3, 1, -2, 3, 4, -5 } },
+            new object[] { new ushort[] { 7, 5, 3, 1, 2, 3, 4, 5 } },
+            new object[] { new uint[] { 7u, 5u, 3u, 1u, 2u, 3u, 4u, 5u } },
+            new object[] { new ulong[] { 7ul, 5ul, 3ul, 1ul, 2ul, 3ul, 4ul, 5ul } }
+        };
+
+        [Theory]
+        [MemberData(nameof(NewIntegerTypeBasicTestData))]
+        public void EncodeAndDecodeNewIntegerTypes(Array input) {
+            using var ms = new MemoryStream();
+            DeltaBinaryPackedEncoder.Encode(input, 0, input.Length, ms);
+
+            Array des = Array.CreateInstance(input.GetType().GetElementType()!, input.Length);
+            int i = DeltaBinaryPackedEncoder.Decode(ms.ToArray(), des, 0, input.Length, out int b);
+
+            Assert.Equal(input, des);
+        }
+
+        #endregion
+
+        #region Edge Case Tests
+
+
+        public static IEnumerable<object[]> NewIntegerTypeEdgeCaseTestData => new List<object[]> {
+            new object[] { new short[] { short.MinValue, short.MaxValue, short.MinValue, short.MaxValue } },
+            new object[] { new ushort[] { ushort.MinValue, ushort.MaxValue, ushort.MinValue, ushort.MaxValue } },
+            new object[] { new uint[] { uint.MinValue, uint.MaxValue, uint.MinValue, uint.MaxValue } },
+            new object[] { new ulong[] { 0ul, (ulong)long.MaxValue, 100ul, 1000ul } }
+        };
+
+        [Theory]
+        [MemberData(nameof(NewIntegerTypeEdgeCaseTestData))]
+        public void EncodeAndDecodeNewIntegerTypes_EdgeCases(Array input) {
+            using var ms = new MemoryStream();
+            DeltaBinaryPackedEncoder.Encode(input, 0, input.Length, ms);
+
+            Array des = Array.CreateInstance(input.GetType().GetElementType()!, input.Length);
+            int i = DeltaBinaryPackedEncoder.Decode(ms.ToArray(), des, 0, input.Length, out int b);
+
+            Assert.Equal(input, des);
+        }
+
+        [Theory]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(uint))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(ulong))]
+        public void EncodeAndDecodeEmptyArray(Type type) {
+            Array emptyInput = Array.CreateInstance(type, 0);
+
+            using var ms = new MemoryStream();
+            DeltaBinaryPackedEncoder.Encode(emptyInput, 0, 0, ms);
+
+            Array des = Array.CreateInstance(type, 0);
+            int i = DeltaBinaryPackedEncoder.Decode(ms.ToArray(), des, 0, 0, out int b);
+
+            Assert.Equal(0, des.Length);
+        }
+
+        [Theory]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(uint))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(ulong))]
+        public void EncodeAndDecodeSingleElement(Type type) {
+            Array singleInput = Array.CreateInstance(type, 1);
+
+            if(type == typeof(short))
+                ((short[])singleInput)[0] = -1000;
+            else if(type == typeof(ushort))
+                ((ushort[])singleInput)[0] = 1000;
+            else if(type == typeof(int))
+                ((int[])singleInput)[0] = -100000;
+            else if(type == typeof(uint))
+                ((uint[])singleInput)[0] = 100000u;
+            else if(type == typeof(long))
+                ((long[])singleInput)[0] = -1000000L;
+            else if(type == typeof(ulong))
+                ((ulong[])singleInput)[0] = 1000000ul;
+
+            using var ms = new MemoryStream();
+            DeltaBinaryPackedEncoder.Encode(singleInput, 0, 1, ms);
+
+            Array des = Array.CreateInstance(type, 1);
+            int i = DeltaBinaryPackedEncoder.Decode(ms.ToArray(), des, 0, 1, out int b);
+
+            Assert.Equal(singleInput.GetValue(0), des.GetValue(0));
+        }
+
+        #endregion
+
+        #region ULong Fallback Tests
+
+        [Fact]
+        public void EncodeUInt64_ExceedsInt64Max_ShouldThrowNotSupportedException() {
+            ulong[] input = new ulong[] { ulong.MaxValue, (ulong)long.MaxValue + 1, ulong.MaxValue - 1 };
+
+            using var ms = new MemoryStream();
+
+            Assert.Throws<NotSupportedException>(() =>
+                DeltaBinaryPackedEncoder.Encode(input, 0, input.Length, ms));
+        }
+
+        public static IEnumerable<object[]> UInt64CanEncodeTestData => new List<object[]> {
+            new object[] { new ulong[] { ulong.MaxValue }, false, "ExceedsInt64Max" },
+            new object[] { new ulong[] { 0ul, (ulong)long.MaxValue, 100ul }, true, "WithinInt64Range" },
+            new object[] { new ulong[] { 0ul, (ulong)long.MaxValue, ulong.MaxValue }, false, "MixedRange" },
+            new object[] { new ulong[0], true, "EmptyArray" },
+            new object[] { new ulong[] { (ulong)long.MaxValue + 1 }, false, "SingleElementExceedsMax" }
+        };
+
+        [Theory]
+        [MemberData(nameof(UInt64CanEncodeTestData))]
+        public void CanEncode_UInt64_VariousScenarios(ulong[] input, bool expectedResult, string scenario) {
+            bool canEncode = DeltaBinaryPackedEncoder.CanEncode(input, 0, input.Length);
+
+            Assert.Equal(expectedResult, canEncode);
+        }
+
+        #endregion
+
+        #region Performance Benchmark Tests
+
+
+        [Theory]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void PerformanceTest_UInt16_Sequential(int count) {
+            ushort[] input = Enumerable.Range(0, count).Select(i => (ushort)(i % 65536)).ToArray();
+
+            using var ms = new MemoryStream();
+            DeltaBinaryPackedEncoder.Encode(input, 0, input.Length, ms);
+
+            ushort[] des = new ushort[input.Length];
+            int decoded = DeltaBinaryPackedEncoder.Decode(ms.ToArray(), des, 0, input.Length, out int _);
+
+            Assert.Equal(input, des);
+            Assert.Equal(input.Length, decoded);
+        }
+
+        [Theory]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void PerformanceTest_UInt32_Sequential(int count) {
+            uint[] input = Enumerable.Range(0, count).Select(i => (uint)i).ToArray();
+
+            using var ms = new MemoryStream();
+            DeltaBinaryPackedEncoder.Encode(input, 0, input.Length, ms);
+
+            uint[] des = new uint[input.Length];
+            int decoded = DeltaBinaryPackedEncoder.Decode(ms.ToArray(), des, 0, input.Length, out int _);
+
+            Assert.Equal(input, des);
+            Assert.Equal(input.Length, decoded);
+        }
+
+        [Theory]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void PerformanceTest_UInt64_Sequential(int count) {
+            ulong[] input = Enumerable.Range(0, count).Select(i => (ulong)i).ToArray();
+
+            using var ms = new MemoryStream();
+            DeltaBinaryPackedEncoder.Encode(input, 0, input.Length, ms);
+
+            ulong[] des = new ulong[input.Length];
+            int decoded = DeltaBinaryPackedEncoder.Decode(ms.ToArray(), des, 0, input.Length, out int _);
+
+            Assert.Equal(input, des);
+            Assert.Equal(input.Length, decoded);
+        }
+
+        [Fact]
+        public void CompressionRatio_TestAllTypes() {
+            int count = 10000;
+
+            // Test sequential data compression for each type
+            Type[] types = new[] {
+                typeof(short), typeof(ushort),
+                typeof(int), typeof(uint), typeof(long), typeof(ulong)
+            };
+
+            foreach(Type type in types) {
+                Array input = CreateSequentialArray(type, count);
+
+                using var ms = new MemoryStream();
+                DeltaBinaryPackedEncoder.Encode(input, 0, input.Length, ms);
+
+                int originalSize = GetTypeSize(type) * count;
+                int encodedSize = (int)ms.Length;
+
+                Assert.True(encodedSize < originalSize, $"Type {type.Name}: encoded size ({encodedSize}) should be less than original size ({originalSize})");
+
+            }
+        }
+
+        private static Array CreateSequentialArray(Type type, int count) {
+            Array array = Array.CreateInstance(type, count);
+
+            if(type == typeof(short)) {
+                for(int i = 0; i < count; i++)
+                    ((short[])array)[i] = (short)(i % 32768);
+            } else if(type == typeof(ushort)) {
+                for(int i = 0; i < count; i++)
+                    ((ushort[])array)[i] = (ushort)(i % 65536);
+            } else if(type == typeof(int)) {
+                for(int i = 0; i < count; i++)
+                    ((int[])array)[i] = i;
+            } else if(type == typeof(uint)) {
+                for(int i = 0; i < count; i++)
+                    ((uint[])array)[i] = (uint)i;
+            } else if(type == typeof(long)) {
+                for(int i = 0; i < count; i++)
+                    ((long[])array)[i] = i;
+            } else if(type == typeof(ulong)) {
+                for(int i = 0; i < count; i++)
+                    ((ulong[])array)[i] = (ulong)i;
+            }
+
+            return array;
+        }
+
+        private static int GetTypeSize(Type type) {
+            if(type == typeof(short) || type == typeof(ushort))
+                return 2;
+            if(type == typeof(int) || type == typeof(uint))
+                return 4;
+            if(type == typeof(long) || type == typeof(ulong))
+                return 8;
+            throw new ArgumentException($"Unsupported type: {type}");
+        }
+
+        #endregion
     }
 }

--- a/src/Parquet/Encodings/DeltaBinaryPackedEncoder.Variations.cs
+++ b/src/Parquet/Encodings/DeltaBinaryPackedEncoder.Variations.cs
@@ -5,6 +5,338 @@
 
     static partial class DeltaBinaryPackedEncoder {
 
+        private static void FlushShortBlock(Span<short> block, short minDelta,
+            Stream destination,
+            int miniblockCount, int miniblockSize) {
+
+            // min delta can be flushed immediately
+            destination.WriteULEB128((ulong)((long)minDelta).ZigZagEncode());
+
+            // subtract minDelta from all values
+            for(int i = 0; i < block.Length; i++) {
+                block[i] = (short)(block[i] - minDelta);
+            }
+
+            // we need bit widths for each miniblock (after minDelta is applied)
+            Span<byte> bitWidths = stackalloc byte[miniblockCount];
+
+            for(int offset = 0, bwi = 0; offset < block.Length; offset += miniblockSize, bwi++) {
+                int count = Math.Min(miniblockSize, block.Length - offset);
+                if(count < 0)
+                    break;
+
+                int bitwidth = block.Slice(offset, count).CalculateBitWidth();
+                bitWidths[bwi] = (byte)bitwidth;
+            }
+
+            // write bit widths
+            destination.WriteSpan(bitWidths);
+
+            // each miniblock is a list of bit packed ints according to the bit width stored at the begining of the block
+            Span<int> raw8 = stackalloc int[8];
+            for(int i = 0; i < miniblockCount; i++) {
+                int offset = i * miniblockSize;
+                int count = Math.Min(miniblockSize, block.Length - offset);
+                if(count < 1)
+                    break;
+                Span<short> miniblockData = block.Slice(offset, count);
+                // write values in 8
+                int bitWidth = bitWidths[i];
+                byte[] encoded8 = new byte[bitWidth];
+                for(int iv = 0; iv < miniblockData.Length; iv += 8) {
+                    int count8 = Math.Min(8, miniblockData.Length - iv);
+                    // Convert to bit packing type for bit packing
+                    for(int j = 0; j < count8; j++) {
+                        raw8[j] = (int)miniblockData[iv + j];
+                    }
+                    for(int j = count8; j < 8; j++) {
+                        raw8[j] = 0;
+                    }
+                    BitPackedEncoder.Pack8ValuesLE(raw8, encoded8, bitWidth);
+                    destination.Write(encoded8, 0, bitWidth);
+                }
+            }
+        }
+
+        private static void EncodeShort(ReadOnlySpan<short> data, Stream destination,
+            int blockSize, int miniblockSize) {
+
+            if(data.Length == 0)
+                return;
+
+            // header: <block size in values> <number of miniblocks in a block> <total value count> <first value>
+            int miniblockCount = blockSize / miniblockSize;
+            destination.WriteULEB128((ulong)blockSize);
+            destination.WriteULEB128((ulong)miniblockCount);
+            destination.WriteULEB128((ulong)data.Length);
+            destination.WriteULEB128((ulong)((long)data[0]).ZigZagEncode());
+
+            // each block: <min delta> <list of bitwidths of miniblocks> <miniblocks>
+            Span<short> block = stackalloc short[blockSize];
+            int blockCount = 0;
+            short minDelta = 0;
+            for(int i = 1; i < data.Length; i++) {
+
+                // calculate delta element and minDelta
+                short delta = (short)(data[i] - data[i - 1]);
+                if(blockCount == 0 || delta < minDelta) {
+                    minDelta = delta;
+                }
+                block[blockCount++] = delta;
+
+                // write block
+                if(blockCount == blockSize) {
+                    FlushShortBlock(block.Slice(0, blockCount), minDelta, destination, miniblockCount, miniblockSize);
+                    blockCount = 0;
+                }
+            }
+
+            if(blockCount > 0) {
+                while(blockCount < blockSize) {
+                    block[blockCount++] = minDelta;
+                }
+                FlushShortBlock(block.Slice(0, blockCount), minDelta, destination, miniblockCount, miniblockSize);
+            }
+        }
+
+        private static int DecodeShort(Span<byte> s, Span<short> dest, out int consumedBytes) {
+
+            int spos = 0;
+
+            // The header is defined as follows:
+            // <block size in values> <number of miniblocks in a block> <total value count> <first value>
+
+            int blockSizeInValues = (int)s.ULEB128Decode(ref spos);
+            int miniblocksInABlock = (int)s.ULEB128Decode(ref spos);
+            int totalValueCount = (int)s.ULEB128Decode(ref spos);           // theoretically equal to "valueCount" param
+            short firstValue = (short)s.ReadZigZagVarLong(ref spos);            // the actual first value
+
+            if(totalValueCount == 0) {
+                consumedBytes = spos;
+                return 0;
+            } else if(totalValueCount == 1) {
+                dest[0] = firstValue;
+                consumedBytes = spos;
+                return 1;
+            }
+
+            int valuesPerMiniblock = blockSizeInValues / miniblocksInABlock;
+            int[] vbuf = new int[valuesPerMiniblock];
+
+            // Each block contains
+            // <min delta> <list of bitwidths of miniblocks> <miniblocks>
+
+            short currentValue = firstValue;
+            int read = 1;
+            int destOffset = 0;
+            dest[destOffset++] = firstValue;
+            while(read < totalValueCount && spos < s.Length) {
+                short minDelta = (short)s.ReadZigZagVarLong(ref spos);
+
+                Span<byte> bitWidths = s.Slice(spos, Math.Min(miniblocksInABlock, s.Length - spos));
+                spos += miniblocksInABlock;
+                foreach(byte bitWidth in bitWidths) {
+
+                    // unpack miniblock
+
+                    if(read >= totalValueCount)
+                        break;
+
+                    if(bitWidth == 0) {
+                        // there's not data for bitwidth 0
+                        for(int i = 0; i < valuesPerMiniblock && destOffset < dest.Length; i++, read++) {
+                            if(read >= totalValueCount)
+                                break;
+                            currentValue = (short)(currentValue + minDelta);
+                            dest[destOffset++] = currentValue;
+                        }
+                    } else {
+
+                        // mini block has a size of 8*n, unpack 8 values each time
+                        for(int j = 0; j < valuesPerMiniblock && spos < s.Length; j += 8) {
+                            BitPackedEncoder.Unpack8ValuesLE(s.Slice(Math.Min(spos, s.Length)), vbuf.AsSpan(j), bitWidth);
+                            spos += bitWidth;
+                        }
+
+                        for(int i = 0; i < vbuf.Length && destOffset < dest.Length && read < totalValueCount; i++, read++) {
+                            currentValue = (short)(currentValue + minDelta + (short)vbuf[i]);
+                            dest[destOffset++] = currentValue;
+                        }
+
+                    }
+                }
+            }
+
+            consumedBytes = spos;
+            return read;
+        }
+
+        private static void FlushUshortBlock(Span<ushort> block, ushort minDelta,
+            Stream destination,
+            int miniblockCount, int miniblockSize) {
+
+            // min delta can be flushed immediately
+            destination.WriteULEB128((ulong)((long)minDelta).ZigZagEncode());
+
+            // subtract minDelta from all values
+            for(int i = 0; i < block.Length; i++) {
+                block[i] = (ushort)(block[i] - minDelta);
+            }
+
+            // we need bit widths for each miniblock (after minDelta is applied)
+            Span<byte> bitWidths = stackalloc byte[miniblockCount];
+
+            for(int offset = 0, bwi = 0; offset < block.Length; offset += miniblockSize, bwi++) {
+                int count = Math.Min(miniblockSize, block.Length - offset);
+                if(count < 0)
+                    break;
+
+                int bitwidth = block.Slice(offset, count).CalculateBitWidth();
+                bitWidths[bwi] = (byte)bitwidth;
+            }
+
+            // write bit widths
+            destination.WriteSpan(bitWidths);
+
+            // each miniblock is a list of bit packed ints according to the bit width stored at the begining of the block
+            Span<int> raw8 = stackalloc int[8];
+            for(int i = 0; i < miniblockCount; i++) {
+                int offset = i * miniblockSize;
+                int count = Math.Min(miniblockSize, block.Length - offset);
+                if(count < 1)
+                    break;
+                Span<ushort> miniblockData = block.Slice(offset, count);
+                // write values in 8
+                int bitWidth = bitWidths[i];
+                byte[] encoded8 = new byte[bitWidth];
+                for(int iv = 0; iv < miniblockData.Length; iv += 8) {
+                    int count8 = Math.Min(8, miniblockData.Length - iv);
+                    // Convert to bit packing type for bit packing
+                    for(int j = 0; j < count8; j++) {
+                        raw8[j] = (int)miniblockData[iv + j];
+                    }
+                    for(int j = count8; j < 8; j++) {
+                        raw8[j] = 0;
+                    }
+                    BitPackedEncoder.Pack8ValuesLE(raw8, encoded8, bitWidth);
+                    destination.Write(encoded8, 0, bitWidth);
+                }
+            }
+        }
+
+        private static void EncodeUshort(ReadOnlySpan<ushort> data, Stream destination,
+            int blockSize, int miniblockSize) {
+
+            if(data.Length == 0)
+                return;
+
+            // header: <block size in values> <number of miniblocks in a block> <total value count> <first value>
+            int miniblockCount = blockSize / miniblockSize;
+            destination.WriteULEB128((ulong)blockSize);
+            destination.WriteULEB128((ulong)miniblockCount);
+            destination.WriteULEB128((ulong)data.Length);
+            destination.WriteULEB128((ulong)((long)data[0]).ZigZagEncode());
+
+            // each block: <min delta> <list of bitwidths of miniblocks> <miniblocks>
+            Span<ushort> block = stackalloc ushort[blockSize];
+            int blockCount = 0;
+            ushort minDelta = 0;
+            for(int i = 1; i < data.Length; i++) {
+
+                // calculate delta element and minDelta
+                ushort delta = (ushort)(data[i] - data[i - 1]);
+                if(blockCount == 0 || delta < minDelta) {
+                    minDelta = delta;
+                }
+                block[blockCount++] = delta;
+
+                // write block
+                if(blockCount == blockSize) {
+                    FlushUshortBlock(block.Slice(0, blockCount), minDelta, destination, miniblockCount, miniblockSize);
+                    blockCount = 0;
+                }
+            }
+
+            if(blockCount > 0) {
+                while(blockCount < blockSize) {
+                    block[blockCount++] = minDelta;
+                }
+                FlushUshortBlock(block.Slice(0, blockCount), minDelta, destination, miniblockCount, miniblockSize);
+            }
+        }
+
+        private static int DecodeUshort(Span<byte> s, Span<ushort> dest, out int consumedBytes) {
+
+            int spos = 0;
+
+            // The header is defined as follows:
+            // <block size in values> <number of miniblocks in a block> <total value count> <first value>
+
+            int blockSizeInValues = (int)s.ULEB128Decode(ref spos);
+            int miniblocksInABlock = (int)s.ULEB128Decode(ref spos);
+            int totalValueCount = (int)s.ULEB128Decode(ref spos);           // theoretically equal to "valueCount" param
+            ushort firstValue = (ushort)s.ReadZigZagVarLong(ref spos);            // the actual first value
+
+            if(totalValueCount == 0) {
+                consumedBytes = spos;
+                return 0;
+            } else if(totalValueCount == 1) {
+                dest[0] = firstValue;
+                consumedBytes = spos;
+                return 1;
+            }
+
+            int valuesPerMiniblock = blockSizeInValues / miniblocksInABlock;
+            int[] vbuf = new int[valuesPerMiniblock];
+
+            // Each block contains
+            // <min delta> <list of bitwidths of miniblocks> <miniblocks>
+
+            ushort currentValue = firstValue;
+            int read = 1;
+            int destOffset = 0;
+            dest[destOffset++] = firstValue;
+            while(read < totalValueCount && spos < s.Length) {
+                ushort minDelta = (ushort)s.ReadZigZagVarLong(ref spos);
+
+                Span<byte> bitWidths = s.Slice(spos, Math.Min(miniblocksInABlock, s.Length - spos));
+                spos += miniblocksInABlock;
+                foreach(byte bitWidth in bitWidths) {
+
+                    // unpack miniblock
+
+                    if(read >= totalValueCount)
+                        break;
+
+                    if(bitWidth == 0) {
+                        // there's not data for bitwidth 0
+                        for(int i = 0; i < valuesPerMiniblock && destOffset < dest.Length; i++, read++) {
+                            if(read >= totalValueCount)
+                                break;
+                            currentValue = (ushort)(currentValue + minDelta);
+                            dest[destOffset++] = currentValue;
+                        }
+                    } else {
+
+                        // mini block has a size of 8*n, unpack 8 values each time
+                        for(int j = 0; j < valuesPerMiniblock && spos < s.Length; j += 8) {
+                            BitPackedEncoder.Unpack8ValuesLE(s.Slice(Math.Min(spos, s.Length)), vbuf.AsSpan(j), bitWidth);
+                            spos += bitWidth;
+                        }
+
+                        for(int i = 0; i < vbuf.Length && destOffset < dest.Length && read < totalValueCount; i++, read++) {
+                            currentValue = (ushort)(currentValue + minDelta + (ushort)vbuf[i]);
+                            dest[destOffset++] = currentValue;
+                        }
+
+                    }
+                }
+            }
+
+            consumedBytes = spos;
+            return read;
+        }
+
         private static void FlushIntBlock(Span<int> block, int minDelta,
             Stream destination,
             int miniblockCount, int miniblockSize) {
@@ -165,6 +497,172 @@
             return read;
         }
 
+        private static void FlushUintBlock(Span<uint> block, uint minDelta,
+            Stream destination,
+            int miniblockCount, int miniblockSize) {
+
+            // min delta can be flushed immediately
+            destination.WriteULEB128((ulong)((long)minDelta).ZigZagEncode());
+
+            // subtract minDelta from all values
+            for(int i = 0; i < block.Length; i++) {
+                block[i] = block[i] - minDelta;
+            }
+
+            // we need bit widths for each miniblock (after minDelta is applied)
+            Span<byte> bitWidths = stackalloc byte[miniblockCount];
+
+            for(int offset = 0, bwi = 0; offset < block.Length; offset += miniblockSize, bwi++) {
+                int count = Math.Min(miniblockSize, block.Length - offset);
+                if(count < 0)
+                    break;
+
+                int bitwidth = block.Slice(offset, count).CalculateBitWidth();
+                bitWidths[bwi] = (byte)bitwidth;
+            }
+
+            // write bit widths
+            destination.WriteSpan(bitWidths);
+
+            // each miniblock is a list of bit packed ints according to the bit width stored at the begining of the block
+            Span<long> raw8 = stackalloc long[8];
+            for(int i = 0; i < miniblockCount; i++) {
+                int offset = i * miniblockSize;
+                int count = Math.Min(miniblockSize, block.Length - offset);
+                if(count < 1)
+                    break;
+                Span<uint> miniblockData = block.Slice(offset, count);
+                // write values in 8
+                int bitWidth = bitWidths[i];
+                byte[] encoded8 = new byte[bitWidth];
+                for(int iv = 0; iv < miniblockData.Length; iv += 8) {
+                    int count8 = Math.Min(8, miniblockData.Length - iv);
+                    // Convert to bit packing type for bit packing
+                    for(int j = 0; j < count8; j++) {
+                        raw8[j] = (long)miniblockData[iv + j];
+                    }
+                    for(int j = count8; j < 8; j++) {
+                        raw8[j] = 0;
+                    }
+                    BitPackedEncoder.Pack8ValuesLE(raw8, encoded8, bitWidth);
+                    destination.Write(encoded8, 0, bitWidth);
+                }
+            }
+        }
+
+        private static void EncodeUint(ReadOnlySpan<uint> data, Stream destination,
+            int blockSize, int miniblockSize) {
+
+            if(data.Length == 0)
+                return;
+
+            // header: <block size in values> <number of miniblocks in a block> <total value count> <first value>
+            int miniblockCount = blockSize / miniblockSize;
+            destination.WriteULEB128((ulong)blockSize);
+            destination.WriteULEB128((ulong)miniblockCount);
+            destination.WriteULEB128((ulong)data.Length);
+            destination.WriteULEB128((ulong)((long)data[0]).ZigZagEncode());
+
+            // each block: <min delta> <list of bitwidths of miniblocks> <miniblocks>
+            Span<uint> block = stackalloc uint[blockSize];
+            int blockCount = 0;
+            uint minDelta = 0;
+            for(int i = 1; i < data.Length; i++) {
+
+                // calculate delta element and minDelta
+                uint delta = data[i] - data[i - 1];
+                if(blockCount == 0 || delta < minDelta) {
+                    minDelta = delta;
+                }
+                block[blockCount++] = delta;
+
+                // write block
+                if(blockCount == blockSize) {
+                    FlushUintBlock(block.Slice(0, blockCount), minDelta, destination, miniblockCount, miniblockSize);
+                    blockCount = 0;
+                }
+            }
+
+            if(blockCount > 0) {
+                while(blockCount < blockSize) {
+                    block[blockCount++] = minDelta;
+                }
+                FlushUintBlock(block.Slice(0, blockCount), minDelta, destination, miniblockCount, miniblockSize);
+            }
+        }
+
+        private static int DecodeUint(Span<byte> s, Span<uint> dest, out int consumedBytes) {
+
+            int spos = 0;
+
+            // The header is defined as follows:
+            // <block size in values> <number of miniblocks in a block> <total value count> <first value>
+
+            int blockSizeInValues = (int)s.ULEB128Decode(ref spos);
+            int miniblocksInABlock = (int)s.ULEB128Decode(ref spos);
+            int totalValueCount = (int)s.ULEB128Decode(ref spos);           // theoretically equal to "valueCount" param
+            uint firstValue = (uint)s.ReadZigZagVarLong(ref spos);            // the actual first value
+
+            if(totalValueCount == 0) {
+                consumedBytes = spos;
+                return 0;
+            } else if(totalValueCount == 1) {
+                dest[0] = firstValue;
+                consumedBytes = spos;
+                return 1;
+            }
+
+            int valuesPerMiniblock = blockSizeInValues / miniblocksInABlock;
+            long[] vbuf = new long[valuesPerMiniblock];
+
+            // Each block contains
+            // <min delta> <list of bitwidths of miniblocks> <miniblocks>
+
+            uint currentValue = firstValue;
+            int read = 1;
+            int destOffset = 0;
+            dest[destOffset++] = firstValue;
+            while(read < totalValueCount && spos < s.Length) {
+                uint minDelta = (uint)s.ReadZigZagVarLong(ref spos);
+
+                Span<byte> bitWidths = s.Slice(spos, Math.Min(miniblocksInABlock, s.Length - spos));
+                spos += miniblocksInABlock;
+                foreach(byte bitWidth in bitWidths) {
+
+                    // unpack miniblock
+
+                    if(read >= totalValueCount)
+                        break;
+
+                    if(bitWidth == 0) {
+                        // there's not data for bitwidth 0
+                        for(int i = 0; i < valuesPerMiniblock && destOffset < dest.Length; i++, read++) {
+                            if(read >= totalValueCount)
+                                break;
+                            currentValue += minDelta;
+                            dest[destOffset++] = currentValue;
+                        }
+                    } else {
+
+                        // mini block has a size of 8*n, unpack 8 values each time
+                        for(int j = 0; j < valuesPerMiniblock && spos < s.Length; j += 8) {
+                            BitPackedEncoder.Unpack8ValuesLE(s.Slice(Math.Min(spos, s.Length)), vbuf.AsSpan(j), bitWidth);
+                            spos += bitWidth;
+                        }
+
+                        for(int i = 0; i < vbuf.Length && destOffset < dest.Length && read < totalValueCount; i++, read++) {
+                            currentValue += (uint)(minDelta + (uint)vbuf[i]);
+                            dest[destOffset++] = currentValue;
+                        }
+
+                    }
+                }
+            }
+
+            consumedBytes = spos;
+            return read;
+        }
+
         private static void FlushLongBlock(Span<long> block, long minDelta,
             Stream destination,
             int miniblockCount, int miniblockSize) {
@@ -314,6 +812,172 @@
 
                         for(int i = 0; i < vbuf.Length && destOffset < dest.Length && read < totalValueCount; i++, read++) {
                             currentValue += minDelta + vbuf[i];
+                            dest[destOffset++] = currentValue;
+                        }
+
+                    }
+                }
+            }
+
+            consumedBytes = spos;
+            return read;
+        }
+
+        private static void FlushUlongBlock(Span<ulong> block, ulong minDelta,
+            Stream destination,
+            int miniblockCount, int miniblockSize) {
+
+            // min delta can be flushed immediately
+            destination.WriteULEB128((ulong)((long)minDelta).ZigZagEncode());
+
+            // subtract minDelta from all values
+            for(int i = 0; i < block.Length; i++) {
+                block[i] = block[i] - minDelta;
+            }
+
+            // we need bit widths for each miniblock (after minDelta is applied)
+            Span<byte> bitWidths = stackalloc byte[miniblockCount];
+
+            for(int offset = 0, bwi = 0; offset < block.Length; offset += miniblockSize, bwi++) {
+                int count = Math.Min(miniblockSize, block.Length - offset);
+                if(count < 0)
+                    break;
+
+                int bitwidth = block.Slice(offset, count).CalculateBitWidth();
+                bitWidths[bwi] = (byte)bitwidth;
+            }
+
+            // write bit widths
+            destination.WriteSpan(bitWidths);
+
+            // each miniblock is a list of bit packed ints according to the bit width stored at the begining of the block
+            Span<long> raw8 = stackalloc long[8];
+            for(int i = 0; i < miniblockCount; i++) {
+                int offset = i * miniblockSize;
+                int count = Math.Min(miniblockSize, block.Length - offset);
+                if(count < 1)
+                    break;
+                Span<ulong> miniblockData = block.Slice(offset, count);
+                // write values in 8
+                int bitWidth = bitWidths[i];
+                byte[] encoded8 = new byte[bitWidth];
+                for(int iv = 0; iv < miniblockData.Length; iv += 8) {
+                    int count8 = Math.Min(8, miniblockData.Length - iv);
+                    // Convert to bit packing type for bit packing
+                    for(int j = 0; j < count8; j++) {
+                        raw8[j] = (long)miniblockData[iv + j];
+                    }
+                    for(int j = count8; j < 8; j++) {
+                        raw8[j] = 0;
+                    }
+                    BitPackedEncoder.Pack8ValuesLE(raw8, encoded8, bitWidth);
+                    destination.Write(encoded8, 0, bitWidth);
+                }
+            }
+        }
+
+        private static void EncodeUlong(ReadOnlySpan<ulong> data, Stream destination,
+            int blockSize, int miniblockSize) {
+
+            if(data.Length == 0)
+                return;
+
+            // header: <block size in values> <number of miniblocks in a block> <total value count> <first value>
+            int miniblockCount = blockSize / miniblockSize;
+            destination.WriteULEB128((ulong)blockSize);
+            destination.WriteULEB128((ulong)miniblockCount);
+            destination.WriteULEB128((ulong)data.Length);
+            destination.WriteULEB128((ulong)((long)data[0]).ZigZagEncode());
+
+            // each block: <min delta> <list of bitwidths of miniblocks> <miniblocks>
+            Span<ulong> block = stackalloc ulong[blockSize];
+            int blockCount = 0;
+            ulong minDelta = 0;
+            for(int i = 1; i < data.Length; i++) {
+
+                // calculate delta element and minDelta
+                ulong delta = data[i] - data[i - 1];
+                if(blockCount == 0 || delta < minDelta) {
+                    minDelta = delta;
+                }
+                block[blockCount++] = delta;
+
+                // write block
+                if(blockCount == blockSize) {
+                    FlushUlongBlock(block.Slice(0, blockCount), minDelta, destination, miniblockCount, miniblockSize);
+                    blockCount = 0;
+                }
+            }
+
+            if(blockCount > 0) {
+                while(blockCount < blockSize) {
+                    block[blockCount++] = minDelta;
+                }
+                FlushUlongBlock(block.Slice(0, blockCount), minDelta, destination, miniblockCount, miniblockSize);
+            }
+        }
+
+        private static int DecodeUlong(Span<byte> s, Span<ulong> dest, out int consumedBytes) {
+
+            int spos = 0;
+
+            // The header is defined as follows:
+            // <block size in values> <number of miniblocks in a block> <total value count> <first value>
+
+            int blockSizeInValues = (int)s.ULEB128Decode(ref spos);
+            int miniblocksInABlock = (int)s.ULEB128Decode(ref spos);
+            int totalValueCount = (int)s.ULEB128Decode(ref spos);           // theoretically equal to "valueCount" param
+            ulong firstValue = (ulong)s.ReadZigZagVarLong(ref spos);            // the actual first value
+
+            if(totalValueCount == 0) {
+                consumedBytes = spos;
+                return 0;
+            } else if(totalValueCount == 1) {
+                dest[0] = firstValue;
+                consumedBytes = spos;
+                return 1;
+            }
+
+            int valuesPerMiniblock = blockSizeInValues / miniblocksInABlock;
+            long[] vbuf = new long[valuesPerMiniblock];
+
+            // Each block contains
+            // <min delta> <list of bitwidths of miniblocks> <miniblocks>
+
+            ulong currentValue = firstValue;
+            int read = 1;
+            int destOffset = 0;
+            dest[destOffset++] = firstValue;
+            while(read < totalValueCount && spos < s.Length) {
+                ulong minDelta = (ulong)s.ReadZigZagVarLong(ref spos);
+
+                Span<byte> bitWidths = s.Slice(spos, Math.Min(miniblocksInABlock, s.Length - spos));
+                spos += miniblocksInABlock;
+                foreach(byte bitWidth in bitWidths) {
+
+                    // unpack miniblock
+
+                    if(read >= totalValueCount)
+                        break;
+
+                    if(bitWidth == 0) {
+                        // there's not data for bitwidth 0
+                        for(int i = 0; i < valuesPerMiniblock && destOffset < dest.Length; i++, read++) {
+                            if(read >= totalValueCount)
+                                break;
+                            currentValue += minDelta;
+                            dest[destOffset++] = currentValue;
+                        }
+                    } else {
+
+                        // mini block has a size of 8*n, unpack 8 values each time
+                        for(int j = 0; j < valuesPerMiniblock && spos < s.Length; j += 8) {
+                            BitPackedEncoder.Unpack8ValuesLE(s.Slice(Math.Min(spos, s.Length)), vbuf.AsSpan(j), bitWidth);
+                            spos += bitWidth;
+                        }
+
+                        for(int i = 0; i < vbuf.Length && destOffset < dest.Length && read < totalValueCount; i++, read++) {
+                            currentValue += (ulong)(minDelta + (ulong)vbuf[i]);
                             dest[destOffset++] = currentValue;
                         }
 

--- a/src/Parquet/Encodings/DeltaBinaryPackedEncoder.Variations.tt
+++ b/src/Parquet/Encodings/DeltaBinaryPackedEncoder.Variations.tt
@@ -2,8 +2,15 @@
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
-<# 
-    var types = new[] { "int", "long" };
+<#
+    var supportedTypes = new[] {
+        new { Type = "short", BitPackingType = "int", RequiresConversion = true },
+        new { Type = "ushort", BitPackingType = "int", RequiresConversion = true },
+        new { Type = "int", BitPackingType = "int", RequiresConversion = false },
+        new { Type = "uint", BitPackingType = "long", RequiresConversion = true },
+        new { Type = "long", BitPackingType = "long", RequiresConversion = false },
+        new { Type = "ulong", BitPackingType = "long", RequiresConversion = true }
+    };
 #>
 namespace Parquet.Encodings {
     using System;
@@ -11,7 +18,10 @@ namespace Parquet.Encodings {
     using Parquet.Extensions;
 
     static partial class DeltaBinaryPackedEncoder {
-<# foreach(string nt in types) { 
+<# foreach(var config in supportedTypes) {
+    string nt = config.Type;
+    string bitPackingType = config.BitPackingType;
+    bool requiresConversion = config.RequiresConversion;
     string ntCap = nt.Substring(0, 1).ToUpper() + nt.Substring(1);#>
 
         private static void Flush<#=ntCap#>Block(Span<<#=nt#>> block, <#=nt#> minDelta,
@@ -23,7 +33,11 @@ namespace Parquet.Encodings {
 
             // subtract minDelta from all values
             for(int i = 0; i < block.Length; i++) {
+<# if (requiresConversion && (nt == "short" || nt == "ushort")) { #>
+                block[i] = (<#=nt#>)(block[i] - minDelta);
+<# } else { #>
                 block[i] = block[i] - minDelta;
+<# } #>
             }
 
             // we need bit widths for each miniblock (after minDelta is applied)
@@ -42,7 +56,11 @@ namespace Parquet.Encodings {
             destination.WriteSpan(bitWidths);
 
             // each miniblock is a list of bit packed ints according to the bit width stored at the begining of the block
+<# if (requiresConversion) { #>
+            Span<<#=bitPackingType#>> raw8 = stackalloc <#=bitPackingType#>[8];
+<# } else { #>
             Span<<#=nt#>> raw8 = stackalloc <#=nt#>[8];
+<# } #>
             for(int i = 0; i < miniblockCount; i++) {
                 int offset = i * miniblockSize;
                 int count = Math.Min(miniblockSize, block.Length - offset);
@@ -54,7 +72,17 @@ namespace Parquet.Encodings {
                 byte[] encoded8 = new byte[bitWidth];
                 for(int iv = 0; iv < miniblockData.Length; iv += 8) {
                     int count8 = Math.Min(8, miniblockData.Length - iv);
+<# if (requiresConversion) { #>
+                    // Convert to bit packing type for bit packing
+                    for(int j = 0; j < count8; j++) {
+                        raw8[j] = (<#=bitPackingType#>)miniblockData[iv + j];
+                    }
+                    for(int j = count8; j < 8; j++) {
+                        raw8[j] = 0;
+                    }
+<# } else { #>
                     miniblockData.Slice(iv, count8).CopyTo(raw8);
+<# } #>
                     BitPackedEncoder.Pack8ValuesLE(raw8, encoded8, bitWidth);
                     destination.Write(encoded8, 0, bitWidth);
                 }
@@ -81,7 +109,11 @@ namespace Parquet.Encodings {
             for(int i = 1; i < data.Length; i++) {
 
                 // calculate delta element and minDelta
+<# if (requiresConversion && (nt == "short" || nt == "ushort")) { #>
+                <#=nt#> delta = (<#=nt#>)(data[i] - data[i - 1]);
+<# } else { #>
                 <#=nt#> delta = data[i] - data[i - 1];
+<# } #>
                 if(blockCount == 0 || delta < minDelta) {
                     minDelta = delta;
                 }
@@ -124,7 +156,11 @@ namespace Parquet.Encodings {
             }
 
             int valuesPerMiniblock = blockSizeInValues / miniblocksInABlock;
+<# if (requiresConversion) { #>
+            <#= bitPackingType#>[] vbuf = new <#= bitPackingType#>[valuesPerMiniblock];
+<# } else { #>
             <#= nt#>[] vbuf = new <#= nt#>[valuesPerMiniblock];
+<# } #>
 
             // Each block contains
             // <min delta> <list of bitwidths of miniblocks> <miniblocks>
@@ -150,7 +186,11 @@ namespace Parquet.Encodings {
                         for(int i = 0; i < valuesPerMiniblock && destOffset < dest.Length; i++, read++) {
                             if(read >= totalValueCount)
                                 break;
+<# if (requiresConversion && (nt == "short" || nt == "ushort")) { #>
+                            currentValue = (<#=nt#>)(currentValue + minDelta);
+<# } else { #>
                             currentValue += minDelta;
+<# } #>
                             dest[destOffset++] = currentValue;
                         }
                     } else {
@@ -162,7 +202,13 @@ namespace Parquet.Encodings {
                         }
 
                         for(int i = 0; i < vbuf.Length && destOffset < dest.Length && read < totalValueCount; i++, read++) {
+<# if (requiresConversion && (nt == "short" || nt == "ushort")) { #>
+                            currentValue = (<#=nt#>)(currentValue + minDelta + (<#=nt#>)vbuf[i]);
+<# } else if (requiresConversion) { #>
+                            currentValue += (<#=nt#>)(minDelta + (<#=nt#>)vbuf[i]);
+<# } else { #>
                             currentValue += minDelta + vbuf[i];
+<# } #>
                             dest[destOffset++] = currentValue;
                         }
 

--- a/src/Parquet/Encodings/DeltaBinaryPackedEncoder.cs
+++ b/src/Parquet/Encodings/DeltaBinaryPackedEncoder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Parquet.Data;
 using Parquet.Extensions;
 using Parquet.Meta;
@@ -9,12 +10,50 @@ namespace Parquet.Encodings {
     /// DELTA_BINARY_PACKED (https://github.com/apache/parquet-format/blob/master/Encodings.md#delta-encoding-delta_binary_packed--5)
     /// fastparquet sample: https://github.com/dask/fastparquet/blob/c59e105537a8e7673fa30676dfb16d9fa5fb1cac/fastparquet/cencoding.pyx#L232
     /// golang sample: https://github.com/xitongsys/parquet-go/blob/62cf52a8dad4f8b729e6c38809f091cd134c3749/encoding/encodingread.go#L270
-    /// 
-    /// Supported Types: INT32, INT64
+    ///
+    /// Supported Types: short, ushort, int, uint, long, ulong
     /// </summary>
     static partial class DeltaBinaryPackedEncoder {
 
-        public static bool IsSupported(System.Type t) => t == typeof(int) || t == typeof(long);
+        public static bool IsSupported(System.Type t) =>
+            t == typeof(int) || t == typeof(long) ||           // native types
+            t == typeof(short) || t == typeof(ushort) ||       // int32 compatible
+            t == typeof(uint) || t == typeof(ulong);           // int64 compatible
+
+        /// <summary>
+        /// Determines whether the specified data can be encoded using delta binary packed encoding.
+        /// For ulong arrays, checks if all values are within the range of long.MaxValue.
+        /// </summary>
+        /// <param name="data">The input array to check</param>
+        /// <param name="offset">Starting offset in the array</param>
+        /// <param name="count">Number of elements to check</param>
+        /// <returns>True if the data can be delta encoded, false otherwise</returns>
+        public static bool CanEncode(Array data, int offset, int count) {
+            if (count == 0) return true;
+
+            // Fast path for ulong overflow check
+            if (data.GetType() == typeof(ulong[])) {
+                return CanEncodeULongArray((ulong[])data, offset, count);
+            }
+
+            return IsSupported(data.GetType().GetElementType() ?? data.GetType());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool CanEncodeULongArray(ulong[] data, int offset, int count) {
+            const ulong maxValue = (ulong)long.MaxValue;
+            int end = offset + count;
+
+            for (int i = offset; i < end; i++) {
+                if (data[i] > maxValue) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+
+
 
         /// <summary>
         /// Encodes the provided data using a delta encoding scheme and writes it to the given destination stream.
@@ -28,40 +67,84 @@ namespace Parquet.Encodings {
         /// <exception cref="NotSupportedException"></exception>
         public static void Encode(Array data, int offset, int count, Stream destination, DataColumnStatistics? stats = null) {
             System.Type t = data.GetType();
-            if(t == typeof(int[])) {
+
+            // Native types - no conversion needed
+            if (t == typeof(int[])) {
                 EncodeInt(((int[])data).AsSpan(offset, count), destination, 1024, 32);
-                if(stats != null)
-                    ParquetPlainEncoder.FillStats((int[])data, stats);
-            } else if(t == typeof(long[])) {
+                if (stats != null)
+                    ParquetPlainEncoder.FillStats(((int[])data).AsSpan(offset, count), stats);
+            }
+            else if (t == typeof(long[])) {
                 EncodeLong(((long[])data).AsSpan(offset, count), destination, 1024, 32);
-                if(stats != null)
-                    ParquetPlainEncoder.FillStats((long[])data, stats);
-            } else {
-                throw new NotSupportedException($"only {Parquet.Meta.Type.INT32} and {Parquet.Meta.Type.INT64} are supported in {Encoding.DELTA_BINARY_PACKED} but type passed is {t}");
+                if (stats != null)
+                    ParquetPlainEncoder.FillStats(((long[])data).AsSpan(offset, count), stats);
+            }
+            // Direct encoding for all supported types
+            else if (t == typeof(short[])) {
+                EncodeShort(((short[])data).AsSpan(offset, count), destination, 1024, 32);
+                if (stats != null)
+                    ParquetPlainEncoder.FillStats(((short[])data).AsSpan(offset, count), stats);
+            }
+            else if (t == typeof(ushort[])) {
+                EncodeUshort(((ushort[])data).AsSpan(offset, count), destination, 1024, 32);
+                if (stats != null)
+                    ParquetPlainEncoder.FillStats(((ushort[])data).AsSpan(offset, count), stats);
+            }
+            else if (t == typeof(uint[])) {
+                EncodeUint(((uint[])data).AsSpan(offset, count), destination, 1024, 32);
+                if (stats != null)
+                    ParquetPlainEncoder.FillStats(((uint[])data).AsSpan(offset, count), stats);
+            }
+            else if (t == typeof(ulong[])) {
+                if (!CanEncodeULongArray((ulong[])data, offset, count)) {
+                    throw new NotSupportedException($"ulong values exceed long.MaxValue range and cannot be encoded with {Encoding.DELTA_BINARY_PACKED}. Use plain encoding instead.");
+                }
+                EncodeUlong(((ulong[])data).AsSpan(offset, count), destination, 1024, 32);
+                if (stats != null)
+                    ParquetPlainEncoder.FillStats(((ulong[])data).AsSpan(offset, count), stats);
+            }
+            else {
+                throw new NotSupportedException($"type {t} is not supported in {Encoding.DELTA_BINARY_PACKED}");
             }
         }
 
-        public static int Decode(Span<byte> s, Array dest, int destOffset, int valueCount, out int consumedBytes) {
 
-            if(s.Length == 0 && valueCount == 0) {
+
+
+        public static int Decode(Span<byte> s, Array dest, int destOffset, int valueCount, out int consumedBytes) {
+            if (s.Length == 0 && valueCount == 0) {
                 consumedBytes = 0;
                 return 0;
             }
 
             System.Type? elementType = dest.GetType().GetElementType();
-            if(elementType != null) {
-                if(elementType == typeof(long)) {
-                    Span<long> span = ((long[])dest).AsSpan(destOffset);
-                    return DecodeLong(s, span, out consumedBytes);
-                } else if(elementType == typeof(int)) {
-                    Span<int> span = ((int[])dest).AsSpan(destOffset);
-                    return DecodeInt(s, span, out consumedBytes);
-                } else {
-                    throw new NotSupportedException($"only {Parquet.Meta.Type.INT32} and {Parquet.Meta.Type.INT64} are supported in {Encoding.DELTA_BINARY_PACKED} but element type passed is {elementType}");
-                }
+            if (elementType == null) {
+                throw new NotSupportedException($"element type {elementType} is not supported");
             }
 
-            throw new NotSupportedException($"element type {elementType} is not supported");
+            // Native types - no conversion needed
+            if (elementType == typeof(long)) {
+                return DecodeLong(s, ((long[])dest).AsSpan(destOffset), out consumedBytes);
+            }
+            if (elementType == typeof(int)) {
+                return DecodeInt(s, ((int[])dest).AsSpan(destOffset), out consumedBytes);
+            }
+
+            // Direct decoding for all supported types
+            if (elementType == typeof(short)) {
+                return DecodeShort(s, ((short[])dest).AsSpan(destOffset), out consumedBytes);
+            }
+            if (elementType == typeof(ushort)) {
+                return DecodeUshort(s, ((ushort[])dest).AsSpan(destOffset), out consumedBytes);
+            }
+            if (elementType == typeof(uint)) {
+                return DecodeUint(s, ((uint[])dest).AsSpan(destOffset), out consumedBytes);
+            }
+            if (elementType == typeof(ulong)) {
+                return DecodeUlong(s, ((ulong[])dest).AsSpan(destOffset), out consumedBytes);
+            }
+
+            throw new NotSupportedException($"element type {elementType} is not supported in {Encoding.DELTA_BINARY_PACKED}");
         }
 
 
@@ -74,13 +157,49 @@ namespace Parquet.Encodings {
             return 32 - mask.NumberOfLeadingZerosInt();
         }
 
-        //this extension method calculates the position of the most significant bit that is set to 1 
+        //this extension method calculates the position of the most significant bit that is set to 1
         static int CalculateBitWidth(this Span<long> span) {
             long mask = 0;
             for(int i = 0; i < span.Length; i++) {
                 mask |= span[i];
             }
             return 64 - mask.NumberOfLeadingZerosLong();
+        }
+
+        //this extension method calculates the position of the most significant bit that is set to 1
+        static int CalculateBitWidth(this Span<short> span) {
+            int mask = 0;
+            for(int i = 0; i < span.Length; i++) {
+                mask |= (int)span[i];
+            }
+            return 32 - mask.NumberOfLeadingZerosInt();
+        }
+
+        //this extension method calculates the position of the most significant bit that is set to 1
+        static int CalculateBitWidth(this Span<ushort> span) {
+            int mask = 0;
+            for(int i = 0; i < span.Length; i++) {
+                mask |= span[i];
+            }
+            return 32 - mask.NumberOfLeadingZerosInt();
+        }
+
+        //this extension method calculates the position of the most significant bit that is set to 1
+        static int CalculateBitWidth(this Span<uint> span) {
+            long mask = 0;
+            for(int i = 0; i < span.Length; i++) {
+                mask |= span[i];
+            }
+            return 64 - mask.NumberOfLeadingZerosLong();
+        }
+
+        //this extension method calculates the position of the most significant bit that is set to 1
+        static int CalculateBitWidth(this Span<ulong> span) {
+            ulong mask = 0;
+            for(int i = 0; i < span.Length; i++) {
+                mask |= span[i];
+            }
+            return 64 - ((long)mask).NumberOfLeadingZerosLong();
         }
     }
 }

--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -73,11 +73,11 @@ namespace Parquet.File {
             PageHeader ph, MemoryStream data,
             ColumnSizes cs,
             CancellationToken cancellationToken) {
-            
+
             using IronCompress.IronCompressResult compressedData = _compressionMethod == CompressionMethod.None
                 ? new IronCompress.IronCompressResult(data.ToArray(), Codec.Snappy, false)
                 : Compressor.Compress(_compressionMethod, data.ToArray(), _compressionLevel);
-            
+
             ph.UncompressedPageSize = (int)data.Length;
             ph.CompressedPageSize = compressedData.AsSpan().Length;
 
@@ -130,7 +130,9 @@ namespace Parquet.File {
 
             // data page
             using(MemoryStream ms = _rmsMgr.GetStream()) {
-                bool deltaEncode = column.IsDeltaEncodable && _options.UseDeltaBinaryPackedEncoding;
+                Array data = pc.GetPlainData(out int offset, out int count);
+                bool deltaEncode = column.IsDeltaEncodable && _options.UseDeltaBinaryPackedEncoding && DeltaBinaryPackedEncoder.CanEncode(data, offset, count);
+               
                 // data page Num_values also does include NULLs
                 PageHeader ph = _footer.CreateDataPage(column.NumValues, pc.HasDictionary, deltaEncode);
                 if(pc.HasRepetitionLevels) {
@@ -146,8 +148,7 @@ namespace Parquet.File {
                     int bitWidth = pc.Dictionary!.Length.GetBitWidth();
                     ms.WriteByte((byte)bitWidth);   // bit width is stored as 1 byte before encoded data
                     RleBitpackedHybridEncoder.Encode(ms, indexes.AsSpan(0, indexesLength), bitWidth);
-                } else {
-                    Array data = pc.GetPlainData(out int offset, out int count);
+                } else {                
                     if(deltaEncode) {
                         DeltaBinaryPackedEncoder.Encode(data, offset, count, ms, column.Statistics);
                         chunk.MetaData!.Encodings[2] = Encoding.DELTA_BINARY_PACKED;


### PR DESCRIPTION
Enhanced DeltaBinaryPackedEncoder to support `short`, `ushort`, `uint`, and `ulong` types alongside existing `int` and `long`. Updated `IsSupported` and introduced encoding/decoding methods for these types. Added `CanEncode` to validate `ulong` values against `long.MaxValue`.

Implemented comprehensive unit tests covering basic scenarios, edge cases, and performance benchmarks. Updated T4 templates to generate type-specific methods dynamically. Optimized bit-packing logic and added `CalculateBitWidth` for new types.

Integrated `CanEncode` with `DataColumnWriter` to ensure proper fallback for unsupported scenarios.

#599 