### PR TITLE
Add option to have required reference types and use C# nullability annotations

### DIFF
--- a/src/Parquet/Extensions/TypeExtensions.cs
+++ b/src/Parquet/Extensions/TypeExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Reflection;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Parquet {
     static class TypeExtensions {
@@ -21,7 +22,7 @@ namespace Parquet {
         /// <param name="t"></param>
         /// <param name="baseType"></param>
         /// <returns></returns>
-        public static bool TryExtractIEnumerableType(this Type t, out Type? baseType) {
+        public static bool TryExtractIEnumerableType(this Type t, [NotNullWhen(true)] out Type? baseType) {
             if(typeof(byte[]) == t) {
                 //it's a special case to avoid confustion between byte arrays and repeatable bytes
                 baseType = null;
@@ -49,7 +50,7 @@ namespace Parquet {
             }
 
             if(ti.IsArray) {
-                baseType = ti.GetElementType();
+                baseType = ti.GetElementType()!;
                 return true;
             }
 
@@ -77,7 +78,7 @@ namespace Parquet {
                 t.GetInterfaces().Any(x => x.IsGenericType && typeof(IDictionary<,>) == x.GetGenericTypeDefinition()));
         }
 
-        public static bool TryExtractDictionaryType(this Type t, out Type? keyType, out Type? valueType) {
+        public static bool TryExtractDictionaryType(this Type t, [NotNullWhen(true)] out Type? keyType, [NotNullWhen(true)] out Type? valueType) {
             if(t.IsGenericIDictionary()) {
                 TypeInfo ti = t.GetTypeInfo();
                 keyType = ti.GenericTypeArguments[0];

--- a/src/Parquet/Schema/Field.cs
+++ b/src/Parquet/Schema/Field.cs
@@ -140,7 +140,8 @@ namespace Parquet.Schema {
 
             if(obj is not Field other) return false;
 
-            return SchemaType == other.SchemaType && Name == other.Name && Path.Equals(other.Path);
+            return SchemaType == other.SchemaType && Name == other.Name && Path.Equals(other.Path)
+                && IsNullable == other.IsNullable;
         }
 
         /// <summary>

--- a/src/Parquet/Schema/ListField.cs
+++ b/src/Parquet/Schema/ListField.cs
@@ -28,10 +28,10 @@ namespace Parquet.Schema {
         /// </summary>
         public Field Item { get; internal set; }
 
-        private ListField(string name) : base(name, SchemaType.List) {
+        private ListField(string name, bool isNullable) : base(name, SchemaType.List) {
             ContainerName = "list";
             Item = new DataField<int>("invalid");
-            IsNullable = true;  // lists are always nullable
+            IsNullable = isNullable;  // lists are always nullable
         }
 
 
@@ -41,7 +41,9 @@ namespace Parquet.Schema {
         /// <param name="name">Field name</param>
         /// <param name="item">Field representing list element</param>
         /// <param name="containerName">Container name</param>
-        public ListField(string name, Field item, string containerName = DefaultContainerName) : this(name) {
+        /// <param name="isNullable">Nullability of the list</param>
+        public ListField(string name, Field item, string containerName = DefaultContainerName,
+            bool isNullable = true) : this(name, isNullable) {
             Item = item ?? throw new ArgumentNullException(nameof(item));
             _itemAssigned = true;
             ContainerName = containerName;
@@ -56,11 +58,13 @@ namespace Parquet.Schema {
         /// <param name="propertyName">When set, uses this property to get the list's data.  When not set, uses the property that matches the name parameter.</param>
         /// <param name="containerName">Container name</param>
         /// <param name="elementName">Element name</param>
+        /// <param name="isNullable">Nullability of the list</param>
         public ListField(string name,
             Type itemDataType,
             string? propertyName = null,
             string containerName = "list",
-            string? elementName = null) : this(name) {
+            string? elementName = null,
+            bool isNullable = true) : this(name, isNullable) {
             Item = new DataField(elementName ?? name, itemDataType, null, null, propertyName ?? name);
             _itemAssigned = true;
             ContainerName = containerName;
@@ -114,7 +118,7 @@ namespace Parquet.Schema {
         }
 
         internal static ListField CreateWithNoItem(string name, bool isNullable) {
-            return new ListField(name) { IsNullable = isNullable };
+            return new ListField(name, isNullable);
         }
 
         internal override void Assign(Field field) {

--- a/src/Parquet/Schema/MapField.cs
+++ b/src/Parquet/Schema/MapField.cs
@@ -29,7 +29,7 @@ namespace Parquet.Schema {
         /// <summary>
         /// Declares a map field
         /// </summary>
-        public MapField(string name, Field keyField, Field valueField)
+        public MapField(string name, Field keyField, Field valueField, bool isNullable = true)
            : base(name, SchemaType.Map) {
 
             if(keyField is DataField keyDataField) {
@@ -45,13 +45,13 @@ namespace Parquet.Schema {
             Path = new FieldPath(name, ContainerName);
             Key.PathPrefix = Path;
             Value.PathPrefix = Path;
-            IsNullable = true;
+            IsNullable = isNullable;
         }
 
-        internal MapField(string name)
+        internal MapField(string name, bool isNullable = true)
            : base(name, SchemaType.Map) {
             Key = Value = new DataField<int>("invalid");
-            IsNullable = true;
+            IsNullable = isNullable;
         }
 
         internal override void Assign(Field se) {

--- a/src/Parquet/Serialization/TypeExtensions.cs
+++ b/src/Parquet/Serialization/TypeExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.Json.Serialization;
 using Parquet.Data;
 using Parquet.Encodings;
@@ -20,13 +21,23 @@ namespace Parquet.Serialization {
         private record struct ReflectedSchemaOptions(bool ForWriting, bool UseNullableAnnotations);
         private static readonly ConcurrentDictionary<(Type, ReflectedSchemaOptions), ParquetSchema> _cachedReflectedSchemas = new();
 
+        /// <summary>
+        /// Represents type information associated with a class member, including
+        /// nested type information within generics and arrays.
+        /// </summary>
+        /// <example>
+        /// For a property `List[string?] MyList { get; set; }`, there is a ClassMember
+        /// representation for the property info + top-level type (list of string?)
+        /// and the property info + element type (string?).
+        /// </example>
         abstract class ClassMember {
-
             private readonly MemberInfo _mi;
             private string? _columnName;
+            private Type _currentType;
 
-            protected ClassMember(MemberInfo mi) {
+            protected ClassMember(MemberInfo mi, Type currentType) {
                 _mi = mi;
+                _currentType = currentType;
             }
 
             public string Name => _mi.Name;
@@ -46,7 +57,7 @@ namespace Parquet.Serialization {
                 internal set => _columnName = value;
             }
 
-            public abstract Type MemberType { get; }
+            public Type MemberType => _currentType;
 
             public int? Order {
                 get {
@@ -76,27 +87,114 @@ namespace Parquet.Serialization {
             public ParquetMicroSecondsTimeAttribute? MicroSecondsTimeAttribute => _mi.GetCustomAttribute<ParquetMicroSecondsTimeAttribute>();
 
             public ParquetDecimalAttribute? DecimalAttribute => _mi.GetCustomAttribute<ParquetDecimalAttribute>();
+            
+            /// <summary>
+            /// Determines if this member is explicitly nullable based on C# nullable annotations
+            /// </summary>
+            public bool HasNullableAnnotation()
+            {   
+#if NET6_0_OR_GREATER
+                return _nullabilityInfo.WriteState == NullabilityState.Nullable ||
+                        _nullabilityInfo.ReadState == NullabilityState.Nullable;
+#else
+                return true;
+#endif
+            }
+
+            protected abstract ClassMember MakeCopy();
+
+            public ClassMember GetClassMemberForEnumerableElement() {
+                ClassMember elementCM = MakeCopy();
+                if (_currentType.HasElementType) {
+                    elementCM._currentType = _currentType.GetElementType()!;
+                }
+                else {
+                    elementCM._currentType = _currentType.GenericTypeArguments[0];
+                }
+
+#if NET6_0_OR_GREATER
+                if (_nullabilityInfo.ElementType != null)
+                {
+                    elementCM._nullabilityInfo = _nullabilityInfo.ElementType;
+                }
+                else
+                {
+                    elementCM._nullabilityInfo = _nullabilityInfo.GenericTypeArguments[0];
+                }
+#endif
+                return elementCM;
+            }
+
+            public (ClassMember, ClassMember) GetClassMemberForDictionaryKVP(Type tKey, Type tValue) {
+                Type kvpType = typeof(KeyValuePair<,>).MakeGenericType(tKey, tValue);
+                PropertyInfo piKey = kvpType.GetProperty("Key")!;
+                PropertyInfo piValue = kvpType.GetProperty("Value")!;
+                var cpmKey = new ClassPropertyMember(piKey);
+                var cpmValue = new ClassPropertyMember(piValue);
+                cpmKey.ColumnName = MapField.KeyName;
+                cpmValue.ColumnName = MapField.ValueName;
+
+#if NET6_0_OR_GREATER
+                if (_nullabilityInfo.GenericTypeArguments.Length >= 2)
+                {
+                    cpmKey._nullabilityInfo = _nullabilityInfo.GenericTypeArguments[0];
+                    cpmValue._nullabilityInfo = _nullabilityInfo.GenericTypeArguments[1];
+                }
+#endif
+                return (cpmKey, cpmValue);
+            }
+
+//             public ClassMember GetClassMemberForGenericTypeArg(int position)
+//             {
+//                 ClassMember classMember = MakeCopy();
+// #if NET6_0_OR_GREATER
+//                 classMember._nullabilityInfo = _nullabilityInfo.GenericTypeArguments[position];
+// #endif
+//                 return classMember;
+//             }
+
+//             public ClassMember GetClassMemberForArrayElement()
+//             {
+//                 ClassMember classMember = MakeCopy();
+// #if NET6_0_OR_GREATER
+//                 classMember._nullabilityInfo = _nullabilityInfo.ElementType!;
+// #endif
+//                 return classMember;             
+//             }
+
+#if NET6_0_OR_GREATER
+            protected NullabilityInfo _nullabilityInfo = null!;
+#endif
         }
 
         class ClassPropertyMember : ClassMember {
             private readonly PropertyInfo _pi;
 
-            public ClassPropertyMember(PropertyInfo propertyInfo) : base(propertyInfo) {
+            public ClassPropertyMember(PropertyInfo propertyInfo) : base(propertyInfo, propertyInfo.PropertyType) {
                 _pi = propertyInfo;
+
+#if NET6_0_OR_GREATER
+                NullabilityInfoContext context = new NullabilityInfoContext();
+                _nullabilityInfo = context.Create(_pi);
+#endif
             }
 
-            public override Type MemberType => _pi.PropertyType;
-
+            protected override ClassMember MakeCopy() => new ClassPropertyMember(_pi);
         }
 
         class ClassFieldMember : ClassMember {
             private readonly FieldInfo _fi;
 
-            public ClassFieldMember(FieldInfo fi) : base(fi) {
+            public ClassFieldMember(FieldInfo fi) : base(fi, fi.FieldType) {
                 _fi = fi;
+
+#if NET6_0_OR_GREATER
+                NullabilityInfoContext context = new NullabilityInfoContext();
+                _nullabilityInfo = context.Create(_fi);
+#endif
             }
 
-            public override Type MemberType => _fi.FieldType;
+            protected override ClassMember MakeCopy() => new ClassFieldMember(_fi);
         }
 
         /// <summary>
@@ -112,9 +210,9 @@ namespace Parquet.Serialization {
         /// nullable (e.g., with the nullability operator). When false, reference type fields are
         /// non-required unless explicitly marked with the C# required keyword.
         /// </param>
-        /// <returns></returns>
+        /// <returns>The parquet schema</returns>
         public static ParquetSchema GetParquetSchema(this Type t, bool forWriting,
-            bool useNullableAnnotations = false) {
+         bool useNullableAnnotations = false) {
             ReflectedSchemaOptions options = new ReflectedSchemaOptions(forWriting, useNullableAnnotations);
             if (_cachedReflectedSchemas.TryGetValue((t, options), out ParquetSchema? schema))
             {
@@ -129,7 +227,7 @@ namespace Parquet.Serialization {
         }
 
         class ReflectedSchemaCalculator(ReflectedSchemaOptions opts) {
-            private ReflectedSchemaOptions _opts = opts;
+            private ReflectedSchemaOptions _opts = opts;   
 
             private List<ClassMember> FindMembers(Type t) {
 
@@ -147,11 +245,8 @@ namespace Parquet.Serialization {
                 return members;
             }
 
-            private static Field ConstructDataField(string name, string propertyName, Type t, ClassMember? member) {
+            private Field ConstructDataField(string name, string propertyName, Type t, ClassMember member) {
                 Field r;
-                bool? isNullable = member == null
-                    ? null
-                    : member.IsRequired ? false : null;
 
                 if(t == typeof(DateTime) || t == typeof(DateTime?)) {
                     ParquetTimestampAttribute? tsa = member?.TimestampAttribute;
@@ -187,53 +282,66 @@ namespace Parquet.Serialization {
                 } else {
                     Type? nt = Nullable.GetUnderlyingType(t);
                     if(nt is { IsEnum: true }) {
-                        isNullable = true;
                         t = nt.GetEnumUnderlyingType();
                     }
                     if(t.IsEnum) {
                         t = t.GetEnumUnderlyingType();
                     }
-
-                    r = new DataField(name, t, isNullable, null, propertyName);
+                    bool? shouldBeNullable = ShouldClassMemberBeNullable(member);
+                    r = new DataField(name, t, shouldBeNullable, null, propertyName);
                 }
 
                 return r;
             }
 
+            private bool ShouldClassMemberBeNullable(ClassMember member) {
+                if (member.IsRequired) {
+                    return false;
+                }
+
+                if (Nullable.GetUnderlyingType(member.MemberType) != null) {
+                    return true;
+                }
+
+                if (!member.MemberType.IsNullable()) {
+                    return false;
+                }
+
+                if(_opts.UseNullableAnnotations) {
+                    return member.HasNullableAnnotation();
+                }
+
+                return true;
+            }
+
             private MapField ConstructMapField(string name, string propertyName,
-                Type tKey, Type tValue) {
+                Type tKey, Type tValue, ClassMember cpmDict) {
 
-                Type kvpType = typeof(KeyValuePair<,>).MakeGenericType(tKey, tValue);
-                PropertyInfo piKey = kvpType.GetProperty("Key")!;
-                PropertyInfo piValue = kvpType.GetProperty("Value")!;
-                var cpmKey = new ClassPropertyMember(piKey);
-                var cpmValue = new ClassPropertyMember(piValue);
-                cpmKey.ColumnName = MapField.KeyName;
-                cpmValue.ColumnName = MapField.ValueName;
-
+                (ClassMember cpmKey, ClassMember cpmValue) = cpmDict.GetClassMemberForDictionaryKVP(tKey, tValue);
                 Field keyField = MakeField(cpmKey)!;
                 if(keyField is DataField keyDataField && keyDataField.IsNullable) {
                     keyField.IsNullable = false;
                 }
+
                 Field valueField = MakeField(cpmValue)!;
                 var mf = new MapField(name, keyField, valueField);
                 mf.ClrPropName = propertyName;
+                mf.IsNullable = ShouldClassMemberBeNullable(cpmDict);
                 return mf;
             }
 
             private ListField ConstructListField(string name, string propertyName,
-                Type elementType,
-                ClassMember? member) {
+                Type elementType, ClassMember memberForList) {
 
-                Field listItemField = MakeField(elementType, ListField.ElementName, propertyName, member)!;
-                if(member != null && member.IsListElementRequired) {
+                ClassMember memberForElement = memberForList.GetClassMemberForEnumerableElement();
+                Field listItemField = MakeField(elementType, ListField.ElementName, propertyName, memberForElement)!;
+                if(memberForList.IsListElementRequired) {
                     listItemField.IsNullable = false;
                 }
+
                 ListField lf = new ListField(name, listItemField);
                 lf.ClrPropName = propertyName;
-                if(member != null && member.IsRequired) {
-                    lf.IsNullable = false;
-                }
+                lf.IsNullable = ShouldClassMemberBeNullable(memberForList);
                 return lf;
             }
 
@@ -256,17 +364,18 @@ namespace Parquet.Serialization {
             /// <returns><see cref="DataField"/> or complex field (recursively scans class). Can return null if property is explicitly marked to be ignored.</returns>
             /// <exception cref="NotImplementedException"></exception>
             private Field MakeField(Type t, string columnName, string propertyName,
-                ClassMember? member) {
+                ClassMember member) {
 
                 Type baseType = t.IsNullable() ? t.GetNonNullable() : t;
-                if(member != null && member.IsLegacyRepeatable && !baseType.IsGenericIDictionary() && baseType.TryExtractIEnumerableType(out Type? bti)) {
+                if(member.IsLegacyRepeatable && !baseType.IsGenericIDictionary() && baseType.TryExtractIEnumerableType(out Type? bti)) {
                     baseType = bti!;
+                    member = member.GetClassMemberForEnumerableElement();
                 }
 
                 if(SchemaEncoder.IsSupported(baseType)) {
                     return ConstructDataField(columnName, propertyName, t, member);
                 } else if(t.TryExtractDictionaryType(out Type? tKey, out Type? tValue)) {
-                    return ConstructMapField(columnName, propertyName, tKey!, tValue!);
+                    return ConstructMapField(columnName, propertyName, tKey, tValue, member);
                 } else if(t.TryExtractIEnumerableType(out Type? elementType)) {
                     return ConstructListField(columnName, propertyName, elementType!, member);
                 } else if(baseType.IsClass || baseType.IsInterface || baseType.IsValueType) {
@@ -284,7 +393,15 @@ namespace Parquet.Serialization {
 
                     StructField sf = new StructField(columnName, fields);
                     sf.ClrPropName = propertyName;
-                    sf.IsNullable = baseType.IsNullable() || t.IsSystemNullable();
+                    sf.IsNullable = ShouldClassMemberBeNullable(member);
+                    
+                    // For struct fields, determine nullability based on the type and member
+                    if (member != null) {
+                        
+                    } else {
+                        sf.IsNullable = baseType.IsNullable() || t.IsSystemNullable();
+                    }
+                    
                     return sf;
                 }
 
@@ -305,7 +422,6 @@ namespace Parquet.Serialization {
                 return new ParquetSchema(fields);
             }
         }
-
         /// <summary>
         /// Convert Resolution to TimeUnit
         /// </summary>


### PR DESCRIPTION
Adds feature #618, using the C# `NullabilityInfo` class to check for nullability annotations. I also made a small coding style refactor to store `useWriting` and the new `useNullableAnnotations` option in an instance variable rather than passing through the call stack everywhere. 

Note: potential risky area is behavior around the `[ParquetRequired]` attribute. You may want to double check I preserved this behavior correctly. Another potential risky area is I added nullability check to `Field.Equals`. I couldn't find any existing behavior that would be affected by this, but might be worth double checking as well.