### PR TITLE
Parellise columns writes.

### DIFF
--- a/src/Parquet/File/ColumnMetrics.cs
+++ b/src/Parquet/File/ColumnMetrics.cs
@@ -4,10 +4,25 @@ using Parquet.Meta;
 
 namespace Parquet.File;
 
-class ColumnMetrics {
-    public int CompressedSize;
-    public int UncompressedSize;
-    public readonly List<PageHeader> Pages = new();
+readonly struct ColumnMetrics {
+    public ColumnMetrics() {
+    }
+
+    private ColumnMetrics(PageHeader[] pages, int compressedSize, int uncompressedSize)
+    {
+        _pages = pages;
+        CompressedSize = compressedSize;
+        UncompressedSize = uncompressedSize;
+    }
+
+    readonly PageHeader[] _pages = [];
+    public int CompressedSize { get; }
+    public int UncompressedSize { get; }
+    public IReadOnlyList<PageHeader> Pages => _pages;
+
+    public ColumnMetrics WithAddedSizes((int compressedSize, int uncompressedSize) sizes) => new(_pages, sizes.compressedSize+CompressedSize, sizes.uncompressedSize + UncompressedSize);
+
+    public ColumnMetrics WithAddedPage(PageHeader page) => new([.. _pages, page], CompressedSize, UncompressedSize);
 
     public List<Encoding> GetUsedEncodings() {
         var r = new HashSet<Encoding>();

--- a/src/Parquet/File/ColumnMetrics.cs
+++ b/src/Parquet/File/ColumnMetrics.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Parquet.Meta;
+
+namespace Parquet.File;
+
+class ColumnMetrics {
+    public int CompressedSize;
+    public int UncompressedSize;
+    public readonly List<PageHeader> Pages = new();
+
+    public List<Encoding> GetUsedEncodings() {
+        var r = new HashSet<Encoding>();
+        foreach(PageHeader page in Pages) {
+            if(page.DictionaryPageHeader != null) {
+                r.Add(page.DictionaryPageHeader.Encoding);
+            }
+            if(page.DataPageHeader != null) {
+                r.Add(page.DataPageHeader.Encoding);
+                r.Add(page.DataPageHeader.DefinitionLevelEncoding);
+                r.Add(page.DataPageHeader.RepetitionLevelEncoding);
+            }
+            if(page.DataPageHeaderV2 != null) {
+                r.Add(page.DataPageHeaderV2.Encoding);
+            }
+        }
+        return r.ToList();
+    }
+}

--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -46,10 +46,11 @@ class DataColumnWriter {
     public async Task<ColumnChunk> WriteAsync(
         FieldPath fullPath, DataColumn column,
         CancellationToken cancellationToken = default) {
+        long startPos = _stream.Position;
 
         // Num_values in the chunk does include null values - I have validated this by dumping spark-generated file.
         ColumnChunk chunk = _footer.CreateColumnChunk(
-            _compressionMethod, _stream, _schemaElement.Type!.Value, fullPath, column.NumValues,
+            _compressionMethod, startPos, _schemaElement.Type!.Value, fullPath, column.NumValues,
             _keyValueMetadata);
         if(chunk.MetaData == null)
             throw new InvalidDataException($"{nameof(chunk.MetaData)} can not be null");

--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -48,6 +48,10 @@ class DataColumnWriter {
         CancellationToken cancellationToken = default) {
         long startPos = _stream.Position;
 
+        ColumnMetrics metrics = await WriteColumnAsync(
+            column, _schemaElement,
+            cancellationToken);
+
         // Num_values in the chunk does include null values - I have validated this by dumping spark-generated file.
         ColumnChunk chunk = _footer.CreateColumnChunk(
             _compressionMethod, startPos, _schemaElement.Type!.Value, fullPath, column.NumValues,
@@ -55,9 +59,6 @@ class DataColumnWriter {
         if(chunk.MetaData == null)
             throw new InvalidDataException($"{nameof(chunk.MetaData)} can not be null");
 
-        ColumnMetrics metrics = await WriteColumnAsync(
-            chunk, column, _schemaElement,
-            cancellationToken);
         chunk.MetaData.Encodings = metrics.GetUsedEncodings();
 
         //generate stats for column chunk
@@ -128,7 +129,7 @@ class DataColumnWriter {
         cs.UncompressedSize += ph.UncompressedPageSize;
     }
 
-    private async Task<ColumnMetrics> WriteColumnAsync(ColumnChunk chunk, DataColumn column,
+    private async Task<ColumnMetrics> WriteColumnAsync(DataColumn column,
        SchemaElement tse,
        CancellationToken cancellationToken = default) {
 

--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -57,7 +57,7 @@ class DataColumnWriter {
         Statistics statistics = column.Statistics.ToThriftStatistics(_schemaElement);
 
         // Num_values in the chunk does include null values - I have validated this by dumping spark-generated file.
-        ColumnChunk chunk = _footer.CreateColumnChunk(
+        ColumnChunk chunk = ThriftFooter.CreateColumnChunk(
             _compressionMethod, startPos, _schemaElement.Type!.Value, fullPath, column.NumValues,
             _keyValueMetadata, statistics, metrics);
 

--- a/src/Parquet/File/DataColumnWriter.cs
+++ b/src/Parquet/File/DataColumnWriter.cs
@@ -116,7 +116,7 @@ class DataColumnWriter {
 
         // dictionary page
         if(pc.HasDictionary) {
-            PageHeader ph = _footer.CreateDictionaryPage(pc.Dictionary!.Length, out _);
+            PageHeader ph = ThriftFooter.CreateDictionaryPage(pc.Dictionary!.Length, out _);
             r = r.WithAddedPage(ph);
             using MemoryStream ms = _rmsMgr.GetStream();
             ParquetPlainEncoder.Encode(pc.Dictionary, 0, pc.Dictionary.Length,
@@ -133,7 +133,7 @@ class DataColumnWriter {
             bool deltaEncode = column.IsDeltaEncodable && _options.UseDeltaBinaryPackedEncoding && DeltaBinaryPackedEncoder.CanEncode(data, offset, count);
 
             // data page Num_values also does include NULLs
-            PageHeader ph = _footer.CreateDataPage(column.NumValues, pc.HasDictionary, deltaEncode, out DataPageHeader dph);
+            PageHeader ph = ThriftFooter.CreateDataPage(column.NumValues, pc.HasDictionary, deltaEncode, out DataPageHeader dph);
             r = r.WithAddedPage(ph);
             if(pc.HasRepetitionLevels) {
                 WriteLevels(ms, pc.RepetitionLevels!, pc.RepetitionLevels!.Length, column.Field.MaxRepetitionLevel);

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -129,7 +129,7 @@ namespace Parquet.File {
             return rg;
         }
 
-        public ColumnChunk CreateColumnChunk(CompressionMethod compression, long startPos,
+        public static ColumnChunk CreateColumnChunk(CompressionMethod compression, long startPos,
             Parquet.Meta.Type columnType, FieldPath path, int valuesCount,
             Dictionary<string, string>? keyValueMetadata, Statistics statistics, ColumnMetrics metrics) {
             CompressionCodec codec = (CompressionCodec)(int)compression;

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -129,13 +129,12 @@ namespace Parquet.File {
             return rg;
         }
 
-        public ColumnChunk CreateColumnChunk(CompressionMethod compression, System.IO.Stream output,
+        public ColumnChunk CreateColumnChunk(CompressionMethod compression, long startPos,
             Parquet.Meta.Type columnType, FieldPath path, int valuesCount,
             Dictionary<string, string>? keyValueMetadata) {
             CompressionCodec codec = (CompressionCodec)(int)compression;
 
             var chunk = new ColumnChunk();
-            long startPos = output.Position;
             chunk.FileOffset = startPos;
             chunk.MetaData = new ColumnMetaData();
             chunk.MetaData.NumValues = valuesCount;

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -160,15 +160,15 @@ namespace Parquet.File {
             return chunk;
         }
 
-        public static PageHeader CreateDataPage(int valueCount, bool isDictionary, bool isDeltaEncodable, out DataPageHeader dph) {
-            dph = new DataPageHeader {
+        public static PageHeader CreateDataPage(int valueCount, bool isDictionary, bool isDeltaEncodable, Statistics statistics) {
+            var dph = new DataPageHeader {
                 Encoding = isDictionary
                         ? Encoding.PLAIN_DICTIONARY
                         : isDeltaEncodable ? Encoding.DELTA_BINARY_PACKED : Encoding.PLAIN,
                 DefinitionLevelEncoding = Encoding.RLE,
                 RepetitionLevelEncoding = Encoding.RLE,
                 NumValues = valueCount,
-                Statistics = new Statistics()
+                Statistics = statistics
             };
 
             return new PageHeader {

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -160,7 +160,7 @@ namespace Parquet.File {
             return chunk;
         }
 
-        public PageHeader CreateDataPage(int valueCount, bool isDictionary, bool isDeltaEncodable, out DataPageHeader dph) {
+        public static PageHeader CreateDataPage(int valueCount, bool isDictionary, bool isDeltaEncodable, out DataPageHeader dph) {
             dph = new DataPageHeader {
                 Encoding = isDictionary
                         ? Encoding.PLAIN_DICTIONARY
@@ -177,7 +177,7 @@ namespace Parquet.File {
             };
         }
 
-        public PageHeader CreateDictionaryPage(int numValues, out DictionaryPageHeader dph) {
+        public static PageHeader CreateDictionaryPage(int numValues, out DictionaryPageHeader dph) {
             dph = new DictionaryPageHeader {
                 Encoding = Encoding.PLAIN_DICTIONARY,
                 NumValues = numValues

--- a/src/Parquet/File/ThriftFooter.cs
+++ b/src/Parquet/File/ThriftFooter.cs
@@ -131,7 +131,7 @@ namespace Parquet.File {
 
         public ColumnChunk CreateColumnChunk(CompressionMethod compression, long startPos,
             Parquet.Meta.Type columnType, FieldPath path, int valuesCount,
-            Dictionary<string, string>? keyValueMetadata) {
+            Dictionary<string, string>? keyValueMetadata, Statistics statistics, ColumnMetrics metrics) {
             CompressionCodec codec = (CompressionCodec)(int)compression;
 
             var chunk = new ColumnChunk();
@@ -142,7 +142,15 @@ namespace Parquet.File {
             chunk.MetaData.Codec = codec;
             chunk.MetaData.DataPageOffset = startPos;
             chunk.MetaData.PathInSchema = path.ToList();
-            chunk.MetaData.Statistics = new Statistics();
+            chunk.MetaData.Statistics = statistics;
+
+            chunk.MetaData.Encodings = metrics.GetUsedEncodings();
+
+            //the following counters must include both data size and header size
+            chunk.MetaData.TotalCompressedSize = metrics.CompressedSize;
+            chunk.MetaData.TotalUncompressedSize = metrics.UncompressedSize;
+
+
             if(keyValueMetadata != null && keyValueMetadata.Count > 0) {
                 chunk.MetaData.KeyValueMetadata = keyValueMetadata
                     .Select(kv => new KeyValue { Key = kv.Key, Value = kv.Value })

--- a/src/Parquet/OrderedCommitGate.cs
+++ b/src/Parquet/OrderedCommitGate.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Parquet;
+
+sealed class OrderedCommitGate {
+    public record struct Token(int Id);
+
+    int _committedContiguous = 0;
+    int _currentId = 0;
+    readonly HashSet<int> _completed = [];
+    readonly Dictionary<int, TaskCompletionSource<object?>> _waiters = [];
+
+    public Token QueueForCommit() => new(_currentId++);
+
+    public Task WaitForCommit(Token commitToken) {
+        lock(_waiters) {
+            int previousCommitId = commitToken.Id - 1;
+            if(previousCommitId <= _committedContiguous)
+                return Task.CompletedTask;
+            var tcs = new TaskCompletionSource<object?>();
+            _waiters[commitToken.Id] = tcs;
+            return tcs.Task;
+        }
+    }
+
+    public void CommitDone(Token commitToken) {
+        lock(_waiters) {
+            _completed.Add(commitToken.Id);
+
+            // advance contiguous prefix
+            while(_completed.Contains(_committedContiguous + 1)) {
+                _completed.Remove(_committedContiguous + 1);
+                _committedContiguous++;
+            }
+
+            if(_waiters.Count == 0)
+                return;
+
+            // release any waiters whose prerequisite is now satisfied
+            int[] ready = _waiters.Keys
+                .Where(id => id - 1 <= _committedContiguous)
+                .ToArray();
+            foreach(int id in ready) {
+                if(_waiters.TryGetValue(id, out TaskCompletionSource<object?>? tcs)) {
+                    _waiters.Remove(id);
+                    tcs?.SetResult(null);
+                }
+            }
+        }
+    }
+}

--- a/src/Parquet/ParquetRowGroupWriter.cs
+++ b/src/Parquet/ParquetRowGroupWriter.cs
@@ -27,6 +27,7 @@ namespace Parquet {
         private readonly ParquetOptions _formatOptions;
         private readonly RowGroup _owGroup;
         private readonly SchemaElement[] _thschema;
+        private readonly OrderedCommitGate _orderedCommitGate = new();
         private int _colIdx;
 
         internal ParquetRowGroupWriter(ParquetSchema schema,
@@ -99,7 +100,7 @@ namespace Parquet {
 
             FieldPath path = _footer.GetPath(tse);
 
-            ColumnChunk chunk = await DataColumnWriter.WriteAsync(path, column, _stream, tse, _compressionMethod, _formatOptions, _compressionLevel, customMetadata, cancellationToken);
+            ColumnChunk chunk = await DataColumnWriter.WriteAsync(path, column, _stream, tse, _compressionMethod, _formatOptions, _compressionLevel, customMetadata, _orderedCommitGate, cancellationToken);
             _owGroup.Columns.Add(chunk);
 
         }

--- a/src/Parquet/ParquetRowGroupWriter.cs
+++ b/src/Parquet/ParquetRowGroupWriter.cs
@@ -99,13 +99,7 @@ namespace Parquet {
 
             FieldPath path = _footer.GetPath(tse);
 
-            var writer = new DataColumnWriter(_stream, _footer, tse,
-               _compressionMethod,
-               _formatOptions,
-               _compressionLevel,
-               customMetadata);
-
-            ColumnChunk chunk = await writer.WriteAsync(path, column, cancellationToken);
+            ColumnChunk chunk = await DataColumnWriter.WriteAsync(path, column, _stream, tse, _compressionMethod, _formatOptions, _compressionLevel, customMetadata, cancellationToken);
             _owGroup.Columns.Add(chunk);
 
         }


### PR DESCRIPTION
This PR allow to parallelise writes.  
It doesn't change the API, but the parallelisation control is limited due to that.  
The big constraint is that each WriteColumn must be started in order. As soon as it yield, we can start the next one.

But we can now easily introduce another API that allow to write columns in parallel.  

I moved a few things to static to avoid accidentaly modifying states concurrently.  

Each changes are in it's own commented commit, I'd recommand to read the changes commit by commit to follow it.