### PR TITLE
Add IsAdjustedToUTC property to TimeOnlyDataField

### DIFF
--- a/src/Parquet/Encodings/SchemaEncoder.cs
+++ b/src/Parquet/Encodings/SchemaEncoder.cs
@@ -598,7 +598,7 @@ static class SchemaEncoder {
                         tse.Type = Type.INT32;
                         tse.LogicalType = new LogicalType {
                             TIME = new TimeType {
-                                IsAdjustedToUTC = true,
+                                IsAdjustedToUTC = dfTime.IsAdjustedToUTC,
                                 Unit = new TimeUnit { MILLIS = new MilliSeconds() }
                             }
                         };
@@ -608,7 +608,7 @@ static class SchemaEncoder {
                         tse.Type = Type.INT64;
                         tse.LogicalType = new LogicalType {
                             TIME = new TimeType {
-                                IsAdjustedToUTC = true,
+                                IsAdjustedToUTC = dfTime.IsAdjustedToUTC,
                                 Unit = new TimeUnit { MICROS = new MicroSeconds() }
                             }
                         };
@@ -635,7 +635,7 @@ static class SchemaEncoder {
                         tse.Type = Type.INT32;
                         tse.LogicalType = new LogicalType {
                             TIME = new TimeType {
-                                IsAdjustedToUTC = true,
+                                IsAdjustedToUTC = dfTime.IsAdjustedToUTC,
                                 Unit = new TimeUnit { MILLIS = new MilliSeconds() }
                             }
                         };
@@ -645,7 +645,7 @@ static class SchemaEncoder {
                         tse.Type = Type.INT64;
                         tse.LogicalType = new LogicalType {
                             TIME = new TimeType {
-                                IsAdjustedToUTC = true,
+                                IsAdjustedToUTC = dfTime.IsAdjustedToUTC,
                                 Unit = new TimeUnit { MICROS = new MicroSeconds() }
                             }
                         };

--- a/src/Parquet/Schema/TimeOnlyDataField.cs
+++ b/src/Parquet/Schema/TimeOnlyDataField.cs
@@ -12,6 +12,11 @@ namespace Parquet.Schema {
         public TimeSpanFormat TimeSpanFormat { get; }
 
         /// <summary>
+        /// IsAdjustedToUTC
+        /// </summary>
+        public bool IsAdjustedToUTC { get; set; } = true;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TimeOnlyDataField"/> class.
         /// </summary>
         /// <param name="name">The name.</param>

--- a/src/Parquet/Serialization/TypeExtensions.cs
+++ b/src/Parquet/Serialization/TypeExtensions.cs
@@ -165,12 +165,15 @@ namespace Parquet.Serialization {
                 };
 #if NET6_0_OR_GREATER
             } else if(t == typeof(TimeOnly) || t == typeof(TimeOnly?)) {
+                ParquetTimeSpanAttribute? tsaTimeOnly = member?.TimeSpanAttribute;
                 r = new TimeOnlyDataField(name,
                     member?.MicroSecondsTimeAttribute == null
                         ? TimeSpanFormat.MilliSeconds
                         : TimeSpanFormat.MicroSeconds,
                     t == typeof(TimeOnly?),
-                    null, propertyName);
+                    null, propertyName) {
+                    IsAdjustedToUTC = tsaTimeOnly == null ? true : tsaTimeOnly.IsAdjustedToUTC
+                };
 #endif
             } else if(t == typeof(decimal) || t == typeof(decimal?)) {
                 ParquetDecimalAttribute? ps = member?.DecimalAttribute;


### PR DESCRIPTION
   # Add IsAdjustedToUTC property to TimeOnlyDataField
   
   1. TimeOnlyDataField.cs — Added public bool IsAdjustedToUTC { get; set;   } = true;
   2. SchemaEncoder.cs (TimeOnly branch) — 2 hardcoded IsAdjustedToUTC = true → dfTime.IsAdjustedToUTC
   3. SchemaEncoder.cs (TimeSpan branch) — 2 hardcoded IsAdjustedToUTC = true → dfTime.IsAdjustedToUTC
   4. TypeExtensions.cs — Wired ParquetTimeSpanAttribute.IsAdjustedToUTC into TimeOnlyDataField construction

  Backward-compatible: default remains true; untyped fallback paths stay hardcoded to true.