### PR TITLE
Update the snappier version to 1.3.1

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,7 @@
+# 5.6.1
+
+Update the snappier version to 1.3.1 to fix critical vulnerability, by @JonasChristensen90 in #743.
+
 # 5.6.0
 
 - **BREAKING:**: The minimum supported .NET version is 8.

--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -53,7 +53,7 @@
     <!-- Compression libraries -->
     <ItemGroup>
         <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
-        <PackageReference Include="Snappier" Version="1.3.0" />
+        <PackageReference Include="Snappier" Version="1.3.1" />
         <PackageReference Include="ZstdSharp.Port" Version="0.8.7" />
     </ItemGroup>
 


### PR DESCRIPTION
## What:
* Updates the Snappier version to 1.3.1 for version 5.

## Why:
* To fix a high severity vulnerability - https://github.com/brantburnett/Snappier/security/advisories/GHSA-pggp-6c3x-2xmx
* Fixes this issue here: https://github.com/aloneguid/parquet-dotnet/issues/742