### PR TITLE
Fix struct-skip miscount in ThriftCompactProtocolReader

### DIFF
--- a/src/Parquet.Test/ThriftTest.cs
+++ b/src/Parquet.Test/ThriftTest.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using Parquet.Meta;
 using Parquet.Meta.Proto;
 using Xunit;
@@ -10,5 +10,76 @@ public class ThriftTest : TestBase {
     public void TestFileRead_Table() {
         using Stream fs = OpenTestFile("thrift/wide.bin");
         FileMetaData fileMeta = FileMetaData.Read(new ThriftCompactProtocolReader(fs));
+    }
+
+    [Fact]
+    public void SkipField_NestedStruct_ConsumesAllFieldValues() {
+        // Hand-crafted Thrift compact-protocol payload representing an
+        // outer struct with three fields:
+        //   1: i32 = 42
+        //   2: nested struct { 1: i32 = 99 }   <-- skipped via SkipField
+        //   3: i32 = 7                          <-- must remain reachable
+        //
+        // If SkipField(Struct) only reads the nested field's HEADER but
+        // not its VALUE, the read cursor is left mid-value and field 3
+        // is unreachable: ReadNextField mis-parses the leftover value
+        // bytes as a new field header.
+        //
+        // Compact-protocol encoding details:
+        //   field header byte = (delta << 4) | type
+        //   i32 value         = zigzag-varint
+        //
+        //   42 -> zigzag 84       -> varint 0x54
+        //   99 -> zigzag 198      -> varint 0xC6 0x01
+        //    7 -> zigzag 14       -> varint 0x0E
+        //   I32 type=5, Struct type=12, Stop type=0
+        byte[] payload = new byte[] {
+            0x15,                   // field 1, I32
+            0x54,                   //   value 42
+            0x1C,                   // field 2, Struct
+              0x15,                 //   nested field 1, I32
+              0xC6, 0x01,           //     value 99
+              0x00,                 //   nested struct stop
+            0x15,                   // field 3, I32
+            0x0E,                   //   value 7
+            0x00,                   // outer struct stop
+        };
+
+        using var stream = new MemoryStream(payload);
+        var reader = new ThriftCompactProtocolReader(stream);
+
+        reader.StructBegin();
+
+        bool sawField1 = false;
+        bool sawField3 = false;
+        while(reader.ReadNextField(out short fieldId, out CompactType compactType)) {
+            switch(fieldId) {
+                case 1:
+                    Assert.Equal(CompactType.I32, compactType);
+                    Assert.Equal(42, reader.ReadI32());
+                    sawField1 = true;
+                    break;
+                case 3:
+                    Assert.Equal(CompactType.I32, compactType);
+                    Assert.Equal(7, reader.ReadI32());
+                    sawField3 = true;
+                    break;
+                default:
+                    // Treat field 2 (the nested struct) as unknown and
+                    // skip it. This is the path Parquet.Net's auto-
+                    // generated Read methods take for any field id
+                    // newer than they were generated against.
+                    reader.SkipField(compactType);
+                    break;
+            }
+        }
+
+        reader.StructEnd();
+
+        Assert.True(sawField1, "field 1 should have been read");
+        Assert.True(sawField3,
+            "field 3 should still be reachable after SkipField on the " +
+            "non-empty nested struct -- if this fails, SkipField left " +
+            "the read cursor mis-aligned");
     }
 }

--- a/src/Parquet/Meta/Proto/ThriftCompactProtocolReader.cs
+++ b/src/Parquet/Meta/Proto/ThriftCompactProtocolReader.cs
@@ -193,13 +193,22 @@ class ThriftCompactProtocolReader {
                 // Don't try to decode the string, just skip it.
                 ReadBinary();
                 break;
-            //case TType.Uuid:
-            //    await protocol.ReadUuidAsync(cancellationToken);
-            //    break;
+            case CompactType.Uuid:
+                // Apache Thrift compact spec: UUID is 16 raw bytes, no length prefix.
+                _inputStream.Seek(16, SeekOrigin.Current);
+                break;
             case CompactType.Struct:
                 StructBegin();
-                while(ReadNextField(out _, out _)) {
-
+                while(ReadNextField(out _, out CompactType nestedType)) {
+                    // Recurse so we consume each nested field's VALUE,
+                    // not just its header. Without this, the read cursor
+                    // is left mis-aligned partway through the first
+                    // non-empty nested field and the next bytes are
+                    // mis-parsed as field headers -- which then either
+                    // throws when the random byte's low nibble is an
+                    // unhandled CompactType, or (worse) silently returns
+                    // wrong data.
+                    SkipField(nestedType);
                 }
                 StructEnd();
                 break;


### PR DESCRIPTION
## Summary

`SkipField(CompactType.Struct)` in `ThriftCompactProtocolReader` reads each
nested field's header but never consumes the field's *value* — the loop body
is empty:

```csharp
case CompactType.Struct:
    StructBegin();
    while(ReadNextField(out _, out _)) {
        // empty body -- reads field header, doesn't skip its value
    }
    StructEnd();
    break;
```

This works only when the nested struct is empty (just a Stop byte). For any
non-empty nested struct, the read cursor is left mid-value after the first
field, and the next bytes are mis-parsed as a new field header. Eventually a
random byte's low nibble matches an unhandled `CompactType` (commonly 0x0D,
which is `Uuid` in Apache Thrift's compact protocol but not implemented
here) and the parser throws:

```
System.InvalidOperationException: don't know how to skip type Uuid
```

— or, on `master`, the renamed `ThriftProtocolException` with the same
"unexpected data type" wording. The error message points at the random byte
the mis-aligned read encountered, not at any real Uuid field on the wire.

## Trigger

The bug only fires when Parquet.Net's auto-generated `Read` methods (e.g.
`ColumnMetaData.Read`, `RowGroup.Read`) encounter a struct-type field
*newer than they were generated against* and fall back to `SkipField`. As
long as the auto-generated readers stay current with `parquet-format.thrift`
this is dead code — but the moment a writer emits a newer struct field, the
mis-alignment fires.

The reproducible case I hit: `parquet-rs >= 58` (Rust crate from
`apache/arrow-rs`) writes `ColumnMetaData.size_statistics` (field 16, a
struct), which Parquet.Net 4.25.0 / 5.6.1 / 6.0.1's `ColumnMetaData.Read`
does not enumerate (their newest known field is `BloomFilterLength`, id 15),
so it falls back to `SkipField(Struct)` and the bug fires on the first
non-empty `SizeStatistics` field.

## Fix

Recurse into `SkipField` inside the struct-skip loop body so each nested
field's value is consumed:

```csharp
case CompactType.Struct:
    StructBegin();
    while(ReadNextField(out _, out CompactType nestedType)) {
        SkipField(nestedType);
    }
    StructEnd();
    break;
```

Also implementing the previously commented-out `Uuid` case (16 raw bytes
per Apache Thrift compact spec) so `SkipField` can handle a real Uuid field
if a future spec addition emits one — without this, the legitimate Uuid
type would still throw.

## Test

Added a focused regression test in `src/Parquet.Test/ThriftTest.cs` that
constructs a 9-byte hand-crafted compact-protocol payload representing an
outer struct with three fields, where field 2 is a non-empty nested struct.
The test calls `SkipField(Struct)` on field 2 and asserts field 3 remains
reachable. Without the fix, field 3 is never parsed (the read cursor is
mis-aligned after the first nested field's header). With the fix, all
three fields read cleanly.

## Validation

This patch was developed against `4.25.0` and verified end-to-end on a
real-world cross-implementation scenario (~1.4 GB of Stellar mass-spec
data, 462 802 rows, 40 columns, written by `parquet-rs 58.1.0` and read
by Parquet.Net): pre-patch fails immediately on metadata read; post-patch
reads the entire metadata + data correctly. After porting forward to
`master` here, the new unit test fails on the unmodified upstream code
and passes with this patch applied.

## Notes

- I used `gh repo fork` and pushed a single-purpose branch
  `fix-thrift-struct-skip` to my fork. Happy to split the Uuid case into a
  separate PR if you'd prefer to land just the bug fix and treat the Uuid
  case as a feature addition.
- I checked Parquet.Net 5.6.1 and 6.0.1 sources — they have the same
  broken `case CompactType.Struct` body, so this fix likely applies
  cleanly to any release branch you maintain.

🤖 This bug was diagnosed and the fix proposed by [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7) while it was helping me port the Skyline-side osprey scoring code to read Rust-emitted parquet files. I reviewed both the diagnosis and the patch.
