### PR TITLE
Add back link to Parquet.FSharp

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1074,7 +1074,7 @@ await merger.MergeFilesAsync(destination);
 - [DeltaIO - Delta Lake implementation in pure .NET](https://github.com/aloneguid/delta).
 - [Personal Data Warehouse - Import(Excel/Parquet/SQL/Fabric)-Transform(C#/Python)-Report(SSRS)](https://github.com/BlazorData-Net/PersonalDataWarehouse).
 - [FastBCP - Export to parquet files in parallel from Oracle, SQL Server, MySQL, PostgreSQL, ODBC, Teradata, Netezza, SAP HANA, ClickHouse in one command line (Windows & Linux)](https://fastbcp.arpe.io/).
-- [Parquet.FSharp - Extension of Parquet.Net that adds first-class support for F# types such as records, options, lists and discriminated unions](https://github.com/rob-earwaker/parquet-fsharp).
+- [Parquet.FSharp - Adds first-class support for F# types such as records, options, lists and discriminated unions](https://github.com/rob-earwaker/parquet-fsharp).
 
 *...raise a PR to appear here...*
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1061,20 +1061,20 @@ await merger.MergeFilesAsync(destination);
 
 ## Used by
 
-- [Azure Cosmos DB Desktop Data Migration Tool](https://github.com/AzureCosmosDB/data-migration-desktop-tool).
-- [RavenDB - An ACID NoSQL Document Database](https://github.com/ravendb/ravendb).
-- [Cinchoo ETL: An ETL framework for .NET](https://github.com/Cinchoo/ChoETL).
-- [ParquetViewer: Simple Windows desktop application for viewing & querying Apache Parquet files](https://github.com/mukunku/ParquetViewer).
-- [ML.NET: Machine Learning for .NET](https://github.com/dotnet/machinelearning).
-- [PSParquet: PowerShell Module for Parquet](https://github.com/Agazoth/PSParquet).
-- [Omni Loader: Self-tuning Database Migration Accelerator](https://www.omniloader.com).
-- [Contoso Data Generator V2 : sample data generator](https://github.com/sql-bi/Contoso-Data-Generator-V2).
-- [Recfuence - An analysis of YouTube's political influence through recommendations]().
-- [Kusto-loco - C# KQL query engine with flexible I/O layers and visualization](https://github.com/NeilMacMullen/kusto-loco).
-- [DeltaIO - Delta Lake implementation in pure .NET](https://github.com/aloneguid/delta).
-- [Personal Data Warehouse - Import(Excel/Parquet/SQL/Fabric)-Transform(C#/Python)-Report(SSRS)](https://github.com/BlazorData-Net/PersonalDataWarehouse).
-- [FastBCP - Export to parquet files in parallel from Oracle, SQL Server, MySQL, PostgreSQL, ODBC, Teradata, Netezza, SAP HANA, ClickHouse in one command line (Windows & Linux)](https://fastbcp.arpe.io/).
-- [Parquet.FSharp - Adds first-class support for F# types such as records, options, lists and discriminated unions](https://github.com/rob-earwaker/parquet-fsharp).
+- [Azure Cosmos DB Desktop Data Migration Tool](https://github.com/AzureCosmosDB/data-migration-desktop-tool)
+- [RavenDB](https://github.com/ravendb/ravendb) - An ACID NoSQL Document Database
+- [Cinchoo ETL](https://github.com/Cinchoo/ChoETL) - An ETL framework for .NET
+- [ParquetViewer](https://github.com/mukunku/ParquetViewer) - Simple Windows desktop application for viewing & querying Apache Parquet files
+- [ML.NET](https://github.com/dotnet/machinelearning) - Machine Learning for .NET
+- [PSParquet](https://github.com/Agazoth/PSParquet) - PowerShell Module for Parquet
+- [Omni Loader](https://www.omniloader.com) - Self-tuning Database Migration Accelerator
+- [Contoso Data Generator V2](https://github.com/sql-bi/Contoso-Data-Generator-V2) - Sample data generator
+- [Recfuence]() - An analysis of YouTube's political influence through recommendations
+- [Kusto-loco](https://github.com/NeilMacMullen/kusto-loco) - C# KQL query engine with flexible I/O layers and visualization
+- [DeltaIO](https://github.com/aloneguid/delta) - Delta Lake implementation in pure .NET
+- [Personal Data Warehouse](https://github.com/BlazorData-Net/PersonalDataWarehouse) - Import(Excel/Parquet/SQL/Fabric)-Transform(C#/Python)-Report(SSRS)
+- [FastBCP](https://fastbcp.arpe.io/) - Export to parquet files in parallel from Oracle, SQL Server, MySQL, PostgreSQL, ODBC, Teradata, Netezza, SAP HANA, ClickHouse in one command line (Windows & Linux)
+- [Parquet.FSharp](https://github.com/rob-earwaker/parquet-fsharp) - Adds first-class support for F# types such as records, options, lists and discriminated unions
 
 *...raise a PR to appear here...*
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1074,7 +1074,7 @@ await merger.MergeFilesAsync(destination);
 - [DeltaIO - Delta Lake implementation in pure .NET](https://github.com/aloneguid/delta).
 - [Personal Data Warehouse - Import(Excel/Parquet/SQL/Fabric)-Transform(C#/Python)-Report(SSRS)](https://github.com/BlazorData-Net/PersonalDataWarehouse).
 - [FastBCP - Export to parquet files in parallel from Oracle, SQL Server, MySQL, PostgreSQL, ODBC, Teradata, Netezza, SAP HANA, ClickHouse in one command line (Windows & Linux)](https://fastbcp.arpe.io/).
-
+- [Parquet.FSharp - Extension of Parquet.Net that adds first-class support for F# types such as records, options, lists and discriminated unions](https://github.com/rob-earwaker/parquet-fsharp).
 
 *...raise a PR to appear here...*
 


### PR DESCRIPTION
The **Parquet.FSharp** link was accidentally removed in https://github.com/aloneguid/parquet-dotnet/pull/704 so I've added that back in.

I've also slightly reformatted the entire list so that the links only enclose the project titles and not the descriptions. I think this makes it a bit easier to identify projects and scan through the list - see before and after screenshots below. Happy to revert this reformatting change though, just let me know!

### Before reformatting

<img width="1896" height="967" alt="image" src="https://github.com/user-attachments/assets/759f8a2b-07cc-47d0-a8c1-ef75cf12d801" />

### After reformatting

<img width="1886" height="960" alt="image" src="https://github.com/user-attachments/assets/35bec4b5-21fb-4c60-8811-8bf7f5c648ab" />